### PR TITLE
fix nlocal for all reduce

### DIFF
--- a/src/Distribution/Gaussian.hpp
+++ b/src/Distribution/Gaussian.hpp
@@ -63,7 +63,7 @@ public:
         }
 
         Kokkos::parallel_reduce(
-            "calc moments of particle distr.", numberOfParticles,
+            "calc moments of particle distr.", nlocal,
             KOKKOS_LAMBDA(
                     const int k, double& cent0, double& cent1, double& cent2) {
                     cent0 += Rview(k)[0];
@@ -72,16 +72,16 @@ public:
             },
             Kokkos::Sum<double>(loc_meanR[0]), Kokkos::Sum<double>(loc_meanR[1]), Kokkos::Sum<double>(loc_meanR[2]));
         Kokkos::fence();
-        ippl::Comm->barrier();
 
         MPI_Allreduce(loc_meanR, meanR, 3, MPI_DOUBLE, MPI_SUM, ippl::Comm->getCommunicator());
+        ippl::Comm->barrier();
 
         for(int i=0; i<3; i++){
            meanR[i] = meanR[i]/(1.*numberOfParticles);
         }
 
         Kokkos::parallel_for(
-                numberOfParticles,KOKKOS_LAMBDA(
+                nlocal, KOKKOS_LAMBDA(
                     const int k) {
                     Rview(k)[0] -= meanR[0];
                     Rview(k)[1] -= meanR[1];
@@ -118,16 +118,16 @@ public:
             },
 	    Kokkos::Sum<double>(loc_meanP[0]), Kokkos::Sum<double>(loc_meanP[1]), Kokkos::Sum<double>(loc_meanP[2]));
         Kokkos::fence();
-        ippl::Comm->barrier();
 
         MPI_Allreduce(loc_meanP, meanP, 3, MPI_DOUBLE, MPI_SUM, ippl::Comm->getCommunicator());
+        ippl::Comm->barrier();
 
         for(int i=0; i<3; i++){
            meanP[i] = meanP[i]/(1.*numberOfParticles);
         }
 
         Kokkos::parallel_for(
-            numberOfParticles,KOKKOS_LAMBDA(
+            nlocal, KOKKOS_LAMBDA(
                     const int k) {
                     Pview(k)[0] -= meanP[0];
                     Pview(k)[1] -= meanP[1];
@@ -140,7 +140,7 @@ public:
         // correct the mean
         double avrgpz = opalDist_m->getAvrgpz();
         Kokkos::parallel_for(
-            numberOfParticles,KOKKOS_LAMBDA(
+            nlocal, KOKKOS_LAMBDA(
                     const int k) {
                     Pview(k)[2] += avrgpz;
             }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | sadr_m |
> | **GitLab Project** | [OPAL/OPAL-X/src](https://gitlab.psi.ch/OPAL/OPAL-X/src) |
> | **GitLab Merge Request** | [fix nlocal for all reduce](https://gitlab.psi.ch/OPAL/OPAL-X/src/merge_requests/10) |
> | **GitLab MR Number** | [10](https://gitlab.psi.ch/OPAL/OPAL-X/src/merge_requests/10) |
> | **Date Originally Opened** | Mon, 19 Aug 2024 |
> | **Date Originally Merged** | Sun, 15 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #8 
Problem was with using total number of particles for parallel reduce, instead of local number of particles (per rank).