### PR TITLE
Rename P3M solver type to FFTTruncatedGreenSolver_t to match new name in IPPL

### DIFF
--- a/src/PartBunch/FieldSolver.cpp
+++ b/src/PartBunch/FieldSolver.cpp
@@ -329,7 +329,7 @@ void FieldSolver<double,3>::runSolver() {
             }
         } else if (this->getStype() == "P3M") {
             if constexpr (Dim == 3) {
-                std::get<P3MSolver_t<double, 3>>(this->getSolver()).solve();
+                std::get<FFTTruncatedGreenSolver_t<double, 3>>(this->getSolver()).solve();
             }
         } else if (this->getStype() == "FFTOPEN") {
             if constexpr (Dim == 3) {

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -132,8 +132,8 @@ public:
                     std::get<FFTSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
                 }
                 if constexpr (Dim == 3) {
-                        if (fs_m->getStype() == "P3M") {
-                            std::get<P3MSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
+                        if (fs_m->getStype() == "TG") {
+                            std::get<FFTTruncatedGreenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
                         } else if (fs_m->getStype() == "OPEN") {
                             std::get<OpenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
                         }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | liemen_a |
> | **GitLab Project** | [OPAL/OPAL-X/src](https://gitlab.psi.ch/OPAL/OPAL-X/src) |
> | **GitLab Merge Request** | [Rename P3M solver type to FFTTruncatedGr...](https://gitlab.psi.ch/OPAL/OPAL-X/src/merge_requests/33) |
> | **GitLab MR Number** | [33](https://gitlab.psi.ch/OPAL/OPAL-X/src/merge_requests/33) |
> | **Date Originally Opened** | Thu, 17 Jul 2025 |
> | **Date Originally Merged** | Thu, 17 Jul 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Cherry picked from binnedFieldSolver to not interfer with the binning-files merge request. This fixes a compilation issue that arises since the P3M solver was renamed in a [recent ippl merge](https://github.com/IPPL-framework/ippl/pull/334).