### PR TITLE
Add .gitattributes to ignore generated notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Optionally mark notebooks as generated to ignore them in language stats
+*.ipynb linguist-generated=true


### PR DESCRIPTION
Optionally mark Jupyter notebooks as generated to ignore in language stats.