### PR TITLE
Compatibility for cmake version 3.27 and earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 # but disable c++20 module scanning until we have better support for it this seems to cause some
 # problems when using gcc@14
 if(POLICY CMP0155)
-cmake_policy(SET CMP0155 OLD)
+    cmake_policy(SET CMP0155 OLD)
 endif()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
CMP0155 is only availlable from  cmake 3.28 and on.
Inserting the conditional policy set:

```
if(POLICY CMP0155)
cmake_policy(SET CMP0155 OLD)
endif()
```

avoids the unknown policy error, and enables successfull compilations and runs for old cmake versions.