### PR TITLE
Replace hardcoded transformations in ParallelTracker::computeSpaceChargeFields()

### DIFF
--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -397,7 +397,7 @@ void ParallelTracker::execute() {
             resetFields();
             
             // Space charge field computation
-            computeSpaceChargeFields(step);
+            //computeSpaceChargeFields(step);
            
             // External field computation
             computeExternalFields(oth);


### PR DESCRIPTION
The coordinate transformations in `ParallelTracker::computeSpaceChargeFields()` used to be hardcoded. This PR replaces it with the member functions `CoordinateSystemTrafo::transformBunchTo` and `CoordinateSystemTrafo::RotateBunchTo`.
This closes #164.