### PR TITLE
removed capture by reference in Multipole::computeField.

### DIFF
--- a/src/AbsBeamline/Multipole.cpp
+++ b/src/AbsBeamline/Multipole.cpp
@@ -447,8 +447,8 @@ void Multipole::computeField(
     Vector_t<double, 3> R, 
     Vector_t<double, 3>& /*E*/, 
     Vector_t<double, 3>& B,
-    const Kokkos::View<double*>& NormalComponents,
-    const Kokkos::View<double*>& SkewComponents,
+    const Kokkos::View<double*> NormalComponents,
+    const Kokkos::View<double*> SkewComponents,
     int max_NormalComponent,
     int max_SkewComponent) 
 {

--- a/src/AbsBeamline/Multipole.h
+++ b/src/AbsBeamline/Multipole.h
@@ -194,8 +194,8 @@ private:
         Vector_t<double, 3> R, 
         Vector_t<double, 3>& E, 
         Vector_t<double, 3>& B,
-        const Kokkos::View<double*>& NormalComponents,
-        const Kokkos::View<double*>& SkewComponents,
+        const Kokkos::View<double*> NormalComponents,
+        const Kokkos::View<double*> SkewComponents,
         int max_NormalComponent,
         int max_SkewComponent);
 


### PR DESCRIPTION
This PR replaces the capture by reference of views in `Multipole::computeField()` with capture by value. 
This is the intended way to capture views and closes #180 .