### PR TITLE
Fix FIELD_DEBUG flag propagation

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -26,14 +26,7 @@ if(OPALX_USE_ALTERNATIVE_VARIANT)
   add_definitions(-DOPALX_USE_ALTERNATIVE_VARIANT)
 endif()
 
-# === Field solver debug flag (enables field dumps at runtime when compiled in) ===
-# This defines the preprocessor symbol used in the sources (#ifdef OPALX_FIELD_DEBUG)
-if(OPALX_FIELD_DEBUG)
-  message(STATUS "⚠️  OPALX_FIELD_DEBUG enabled — field dumps will be emitted during simulation")
-  add_compile_definitions(-DOPALX_FIELD_DEBUG)
-endif()
-
-# === Code coverage options ===m
+# === Code coverage options ===
 if(OPALX_ENABLE_COVERAGE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
   message(STATUS "${ColorYellow}Code coverage enabled.${ColorReset}")
   add_compile_options(-fprofile-arcs -ftest-coverage -g)

--- a/cmake/PlatformOptions.cmake
+++ b/cmake/PlatformOptions.cmake
@@ -25,3 +25,9 @@ endif()
 
 # Define macro for use in source code
 target_compile_definitions(opalx PUBLIC OPALX_ENABLE_TIMER_FENCES=${TimerFences})
+
+# Field debug option - apply compile definition to target
+if(OPALX_FIELD_DEBUG)
+  message(STATUS "⚠️  OPALX_FIELD_DEBUG enabled — field dumps will be emitted during simulation")
+  target_compile_definitions(opalx PUBLIC OPALX_FIELD_DEBUG)
+endif()


### PR DESCRIPTION
closes #169 

I forgot a `target_compile_definitions` call in the cmake, see new comment in the issue thread #169. Also first I put it inside `CompilerOptions`. However, `PlatformOptions` seems more appropriate for OPALX specific flags.