### PR TITLE
Explicit Quadrupole Element 

### DIFF
--- a/src/Elements/CMakeLists.txt
+++ b/src/Elements/CMakeLists.txt
@@ -6,6 +6,7 @@ set (_SRCS
     OpalMarker.cpp
     OpalMultipole.cpp
     OpalMultipoleT.cpp
+    OpalQuadrupole.cpp
     OpalSolenoid.cpp
     OpalBeamline.cpp
     OpalRingDefinition.cpp      
@@ -25,6 +26,7 @@ set (HDRS
     OpalMarker.h
     OpalMultipole.h
     OpalMultipoleT.h
+    OpalQuadrupole.h
     OpalSource.h
     OpalSolenoid.h
     OpalTravelingWave.h

--- a/src/Elements/OpalQuadrupole.cpp
+++ b/src/Elements/OpalQuadrupole.cpp
@@ -1,0 +1,108 @@
+//
+// Class OpalQuadrupole
+//   The QUADRUPOLE element.
+//
+//   A convenience wrapper around MULTIPOLE that accepts a single
+//   quadrupole strength K1 instead of the full KN vector.
+//   Internally the element is represented as a MultipoleRep with
+//   KN = {0, K1}.
+//
+// Copyright (c) 2024 – 2026, Paul Scherrer Institut, Villigen PSI, Switzerland
+// All rights reserved
+//
+// This file is part of OPAL.
+//
+// OPAL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with OPAL. If not, see <https://www.gnu.org/licenses/>.
+//
+#include "Elements/OpalQuadrupole.h"
+#include "AbstractObjects/OpalData.h"
+#include "Attributes/Attributes.h"
+#include "BeamlineCore/MultipoleRep.h"
+#include "Physics/Physics.h"
+#include "Fields/BMultipoleField.h"
+
+OpalQuadrupole::OpalQuadrupole():
+    OpalElement(SIZE, "QUADRUPOLE",
+                "The \"QUADRUPOLE\" element defines a thick quadrupole.\n"
+                "It is a convenience wrapper around MULTIPOLE with a single\n"
+                "quadrupole strength K1.\n"
+                "* If the length is non-zero, K1 is per unit length.\n"
+                "* If the length is zero, K1 is the integrated strength.") {
+    itsAttr[K1] = Attributes::makeReal
+                  ("K1", "Normalised quadrupole strength in m^(-2)", 0.0);
+    itsAttr[DK1] = Attributes::makeReal
+                   ("DK1", "Normalised quadrupole strength error in m^(-2)", 0.0);
+    itsAttr[K1S] = Attributes::makeReal
+                   ("K1S", "Normalised skew quadrupole strength in m^(-2)", 0.0);
+    itsAttr[DK1S] = Attributes::makeReal
+                    ("DK1S", "Normalised skew quadrupole strength error in m^(-2)", 0.0);
+
+    registerOwnership();
+
+    setElement(new MultipoleRep("QUADRUPOLE"));
+}
+
+
+OpalQuadrupole::OpalQuadrupole(const std::string &name, OpalQuadrupole *parent):
+    OpalElement(name, parent) {
+    setElement(new MultipoleRep(name));
+}
+
+
+OpalQuadrupole::~OpalQuadrupole()
+{}
+
+
+OpalQuadrupole *OpalQuadrupole::clone(const std::string &name) {
+    return new OpalQuadrupole(name, this);
+}
+
+
+void OpalQuadrupole::print(std::ostream &os) const {
+    OpalElement::print(os);
+}
+
+
+void OpalQuadrupole::update() {
+    OpalElement::update();
+
+    MultipoleRep *mult = dynamic_cast<MultipoleRep *>(getElement());
+    double length = getLength();
+    mult->setElementLength(length);
+
+    // Build a multipole field from the scalar K1 / K1S values.
+    // The KN vector convention is: index 0 = dipole, index 1 = quadrupole, ...
+    BMultipoleField field;
+
+    double k1      = Attributes::getReal(itsAttr[K1]);
+    double dk1     = Attributes::getReal(itsAttr[DK1]);
+    double k1s     = Attributes::getReal(itsAttr[K1S]);
+    double dk1s    = Attributes::getReal(itsAttr[DK1S]);
+
+    double factor = OpalData::getInstance()->getP0() / Physics::c;
+
+    // comp 0 (dipole): strength = 0, factor /= 1
+    factor /= 1.0;  // comp 0
+    field.setNormalComponent(0, 0.0);
+    mult->setNormalComponent(0, 0.0, 0.0);
+    field.setSkewComponent(0, 0.0);
+    mult->setSkewComponent(0, 0.0, 0.0);
+
+    // comp 1 (quadrupole): factor /= 2
+    factor /= 2.0;
+    field.setNormalComponent(1, k1 * factor);
+    mult->setNormalComponent(1, k1, dk1);
+    field.setSkewComponent(1, k1s * factor);
+    mult->setSkewComponent(1, k1s, dk1s);
+
+    mult->setField(field);
+
+    // Transmit "unknown" attributes.
+    OpalElement::updateUnknown(mult);
+}

--- a/src/Elements/OpalQuadrupole.h
+++ b/src/Elements/OpalQuadrupole.h
@@ -1,0 +1,66 @@
+//
+// Class OpalQuadrupole
+//   The QUADRUPOLE element.
+//
+//   A convenience wrapper around MULTIPOLE that accepts a single
+//   quadrupole strength K1 instead of the full KN vector.
+//   Internally the element is represented as a MultipoleRep with
+//   KN = {0, K1}.
+//
+// Copyright (c) 2024 – 2026, Paul Scherrer Institut, Villigen PSI, Switzerland
+// All rights reserved
+//
+// This file is part of OPAL.
+//
+// OPAL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with OPAL. If not, see <https://www.gnu.org/licenses/>.
+//
+#ifndef OPAL_OpalQuadrupole_HH
+#define OPAL_OpalQuadrupole_HH
+
+#include "Elements/OpalElement.h"
+
+
+class OpalQuadrupole: public OpalElement {
+
+public:
+
+    /// The attributes of class OpalQuadrupole.
+    enum {
+        K1 = COMMON,   // Normalised quadrupole strength in m^(-2).
+        DK1,           // Normalised quadrupole strength error in m^(-2).
+        K1S,           // Normalised skew quadrupole strength in m^(-2).
+        DK1S,          // Normalised skew quadrupole strength error in m^(-2).
+        SIZE
+    };
+
+    /// Exemplar constructor.
+    OpalQuadrupole();
+
+    virtual ~OpalQuadrupole();
+
+    /// Make clone.
+    virtual OpalQuadrupole *clone(const std::string &name);
+
+    /// Print the object.
+    virtual void print(std::ostream &) const;
+
+    /// Update the embedded CLASSIC multipole.
+    virtual void update();
+
+private:
+
+    // Not implemented.
+    OpalQuadrupole(const OpalQuadrupole &);
+    void operator=(const OpalQuadrupole &);
+
+    // Clone constructor.
+    OpalQuadrupole(const std::string &name, OpalQuadrupole *parent);
+};
+
+#endif // OPAL_OpalQuadrupole_HH

--- a/src/OpalConfigure/Configure.cpp
+++ b/src/OpalConfigure/Configure.cpp
@@ -67,6 +67,7 @@
 #include "Elements/OpalOffset/OpalLocalCartesianOffset.h"
 #include "Elements/OpalProbe.h"
 #include "Elements/OpalMultipole.h"
+#include "Elements/OpalQuadrupole.h"
 #include "Elements/OpalRingDefinition.h"
 #include "Elements/OpalSolenoid.h"
 #include "Elements/OpalVerticalFFAMagnet.h"
@@ -122,6 +123,7 @@ namespace {
         opal->create(new OpalMarker());
         opal->create(new OpalProbe());
         opal->create(new OpalMultipole());
+        opal->create(new OpalQuadrupole());
         opal->create(new OpalSolenoid());
         opal->create(new OpalRingDefinition());
         opal->create(new Line());


### PR DESCRIPTION

This pull request introduces a new `QUADRUPOLE` element to the codebase, implemented as the `OpalQuadrupole` class. This element serves as a convenience wrapper around the existing `MULTIPOLE` element, allowing users to specify a single quadrupole strength (`K1`) instead of the full multipole vector. The implementation includes source and header files, and cmake integration. 


#### Testing
To verify the implementation I ran the fodocell testcase once with the `Multipole` element and once with the corresponding `Quadrupole` element and indeed they produce identical results. 
