### PR TITLE
Adapt OPALX to IPPL-framework/IPPL#480 

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -17,6 +17,10 @@
 
 #include <cstring>
 
+// Ensure real MPI types are defined before including H5hut.
+// This avoids H5hut's serial stubs redefining MPI_Comm/MPI_Datatype.
+#include <mpi.h>
+
 extern "C" {
   #include "H5hut.h"
 }

--- a/src/PartBunch/FieldSolver.cpp
+++ b/src/PartBunch/FieldSolver.cpp
@@ -213,8 +213,8 @@ void FieldSolver<double,3>::dumpScalField(std::string what) {
     auto spacing  = mesh_mp->getMeshSpacing();
     auto origin   = mesh_mp->getOrigin();
 
-    Field_t<3>::view_type fieldV       = field->getView();
-    Field_t<3>::HostMirror field_hostV = field->getHostMirror();
+    Field_t<3>::view_type fieldV             = field->getView();
+    Field_t<3>::host_mirror_type field_hostV = field->getHostMirror();
     Kokkos::deep_copy(field_hostV, fieldV);     
 
     std::filesystem::path file(dirname);


### PR DESCRIPTION
closes #267 

Fixes the Kokkos types changed after IPPL-framework/IPPL#480.

The explicit mpi include is because, for some reason, OPALX doesn't compile if HDF5 is compiled in serial mode (which happened to me when using a pre-built dependency for HDF5!). Then we get conflicting includes because of some "dummy types" in HDF5. With this ecplicit include everything should be fine.