### PR TITLE
Add simple single-rank guard to skip field computation for 1-particle simulations

### DIFF
--- a/src/PartBunch/PartBunch.cpp
+++ b/src/PartBunch/PartBunch.cpp
@@ -538,7 +538,8 @@ void PartBunch<T, Dim>::computeSelfFields() {
     Inform m("PartBunch::computeSelfFields");
 
     if (ippl::Comm->size() == 1 && this->pcontainer_m->getLocalNum() <= 1) {
-        m << level5 << "WARNING: Only 1 or less particles on rank, skipping computeSelfFields." << endl;
+        this->pcontainer_m->E = 0.0;
+        m << level5 << "WARNING: Only 1 or less particles in this bunch, setting E to 0 for particles." << endl;
         return;
     }
 


### PR DESCRIPTION
closes #292 

Note that the `if (ippl::comm->size() == 1 ...) ...` is necessary, since communication inside `scatter` would have problems on multi-rank if some ranks are almost-empty/skip computation while others don't. 

This PR fixes single-rank simulation when `Nparticles == 1`. This is an edge case that can appear if a flattop distribution with a long `Trise` is chosen. Already worked just fine on multirank before. Now, for this edge case, I set the particle $E$ attribute manually to 0. 

Also note that this doesn't change any physics: one particle doesn't generate a self-field that could act on itself.