### PR TITLE
Fix missing Units include

### DIFF
--- a/src/BasicActions/DumpEMFields.cpp
+++ b/src/BasicActions/DumpEMFields.cpp
@@ -21,6 +21,7 @@
 #include "Attributes/Attributes.h"
 #include "Utilities/OpalException.h"
 #include "Utilities/Util.h"
+#include "Physics/Units.h"
 #include <filesystem>
 #include <fstream>
 


### PR DESCRIPTION
closes #295 

Simply include the `Units.h` file in `DumpEMFields.cpp`.

Edit: also closes #297

Edit 2: since it's just one simple include line, I asked @rammann for a quick review