### PR TITLE
Refactor particle generation in distribution classes to apply emission-source offsets to ALL distributions.

### DIFF
--- a/src/Distribution/FlatTop.cpp
+++ b/src/Distribution/FlatTop.cpp
@@ -131,10 +131,13 @@ void FlatTop::generateUniformDisk(size_type nlocal, size_t nNew) {
     Vector_t<double, 3> sigmaR = sigmaR_m;
     Vector_t<double, 3> R0     = R0_m;
     Vector_t<double, 3> P0     = P0_m;
-    // Beam reference momentum in beta*gamma (set by TrackRun from BEAM); emission source P0 is offset on top.
-    // opalDist_m may be null when FlatTop is constructed directly in unit tests without a Distribution.
+    // Beam reference momentum in beta*gamma (set by TrackRun from BEAM); emission source P0 is
+    // offset on top. opalDist_m may be null when FlatTop is constructed directly in unit tests
+    // without a Distribution.
     const double beamPz = opalDist_m ? opalDist_m->getAvrgpz() : 0.0;
     // Sample (Rx,Ry) on a unit ring, scale with sigmaR, then add R0/P0 (emission source offset).
+    // Note that R0/P0 are applied directly here, since then we only need one loop and don't need to
+    // think too much about which indices to apply the offset to.
     Kokkos::parallel_for(
         "unitDisk", Kokkos::RangePolicy<>(nlocal, nlocal + nNew), KOKKOS_LAMBDA(const size_t j) {
             auto generator = rand_pool.get_state();

--- a/src/Distribution/FromFile.cpp
+++ b/src/Distribution/FromFile.cpp
@@ -314,6 +314,17 @@ void FromFile::generateParticles(size_t& numberOfParticles, Vector_t<double, 3> 
     );
     Kokkos::fence();
 
+    // Apply per-emission-source offsets after all mean-fixing/corrections.
+    // EMISSIONSOURCE offsets are expected to translate the generated bunch
+    // without being affected by the internal "fix mean" logic.
+    const Vector_t<double, 3> R0 = R0_m;
+    const Vector_t<double, 3> P0 = P0_m;
+    Kokkos::parallel_for(
+        nlocal, KOKKOS_LAMBDA(const size_t k) {
+            Rview(k) += R0;
+            Pview(k) += P0;
+        });
+
     Inform mALL("FromFile::generateParticles", INFORM_ALL_NODES);
     mALL << "FromFile: Loaded " << totalParticles << " particles from file '" 
          << filename_m << "'" << endl;

--- a/src/Distribution/Gaussian.cpp
+++ b/src/Distribution/Gaussian.cpp
@@ -2,7 +2,6 @@
 #include "SamplingBase.hpp"
 #include "Gaussian.h"
 #include <algorithm>
-#include <cmath>
 #include <memory>
 
 /**
@@ -167,6 +166,17 @@ void Gaussian::generateParticles(size_t& numberOfParticles, Vector_t<double, 3> 
             Pview(k)[2] += avrgpz; 
         });
     Kokkos::fence();
+
+    // Apply per-emission-source offsets after all mean-fixing/corrections.
+    // EMISSIONSOURCE offsets are expected to translate the generated bunch
+    // without being affected by the internal "fix mean" logic.
+    const Vector_t<double, 3> R0 = R0_m;
+    const Vector_t<double, 3> P0 = P0_m;
+    Kokkos::parallel_for(
+        nlocal, KOKKOS_LAMBDA(const size_t k) {
+            Rview(k) += R0;
+            Pview(k) += P0;
+        });
 
     IpplTimings::stopTimer(samperTimer_m);
 }

--- a/src/Distribution/MultiVariateGaussian.cpp
+++ b/src/Distribution/MultiVariateGaussian.cpp
@@ -351,6 +351,17 @@ void MultiVariateGaussian::generateParticles(size_t &numberOfParticles, Vector_t
         });
     Kokkos::fence();
 
+    // Apply per-emission-source offsets after all mean-fixing/corrections.
+    // EMISSIONSOURCE offsets are expected to translate the generated bunch
+    // without being affected by the internal "fix mean" logic.
+    const Vector_t<double, 3> R0 = R0_m;
+    const Vector_t<double, 3> P0 = P0_m;
+    Kokkos::parallel_for(
+        nlocal, KOKKOS_LAMBDA(const size_t k) {
+            Rview(k) += R0;
+            Pview(k) += P0;
+        });
+
     IpplTimings::stopTimer(samplerTimer_m);
 }
 


### PR DESCRIPTION
As the title states, just a quick addition to #277 (so far the `R0` parameter in `EMISSIONSOURCE` was only wired into flattop; now it's an option in every distribution). With this quick fix, simulations like the following are possible:


https://github.com/user-attachments/assets/fce9fab3-bf3c-4088-9497-113255a16e40

