### PR TITLE
Group workflows by PR -> cancel old ones if new run is triggered

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,6 +16,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
 jobs:
   # ===== CPU SERIAL BUILD =====
   build-cpu-serial-debug:


### PR DESCRIPTION
closes #344 

This will prevent "stale" runs for the same PR if a new run is triggered (e.g. by relabeling or by pushing a new commit). Otherwise the runner concurrency limit is quickly filled when we have more than a few triggered runs. 