### PR TITLE
Exclusive `PC`/`GAMMA`/`ENERGY` or `FROMFILE` options

### DIFF
--- a/src/Structure/Beam.cpp
+++ b/src/Structure/Beam.cpp
@@ -144,13 +144,6 @@ void Beam::execute() {
     }
 
     update();
-    // Check if energy explicitly has been set with the BEAM command
-    if (!itsAttr[GAMMA] && !(itsAttr[ENERGY]) && !(itsAttr[PC])) {
-        throw OpalException(
-            "Beam::execute()",
-            "The energy hasn't been set. "
-            "Set either \"GAMMA\", \"ENERGY\" or \"PC\".");
-    }
 
     if (!(itsAttr[PARTICLE]) && (!itsAttr[MASS] || !(itsAttr[CHARGE]))) {
         throw OpalException(
@@ -244,6 +237,10 @@ bool Beam::isPhoton() const {
 
 double Beam::getFrequency() const {
     return Attributes::getReal(itsAttr[BFREQ]);
+}
+
+bool Beam::hasExplicitEnergy() const {
+    return itsAttr[GAMMA] || itsAttr[ENERGY] || itsAttr[PC];
 }
 
 double Beam::getChargePerParticle() const {

--- a/src/Structure/Beam.h
+++ b/src/Structure/Beam.h
@@ -86,6 +86,9 @@ public:
     /// Throws if `SOURCES` is not set.
     std::string getEmissionSourceListName() const;
 
+    /// True if PC, ENERGY, or GAMMA was explicitly provided by the user.
+    bool hasExplicitEnergy() const;
+
     /// Update the BEAM data.
     virtual void update();
 

--- a/src/Track/TrackRun.cpp
+++ b/src/Track/TrackRun.cpp
@@ -554,6 +554,26 @@ void TrackRun::setupDistributionsAndSamplers(
         opalDist->setDist();
         opalDist->setAvrgPz(avrgpz);
 
+        // FROMFILE distributions carry absolute momenta — the BEAM's
+        // PC/ENERGY/GAMMA would be silently ignored, so forbid the combination.
+        if (opalDist->getType() == DistributionType::FROMFILE) {
+            if (beam->hasExplicitEnergy()) {
+                throw OpalException(
+                    "TrackRun::setupDistributionsAndSamplers()",
+                    "FROMFILE distribution \"" + src->getDistributionName()
+                    + "\" cannot be combined with PC/ENERGY/GAMMA on the BEAM. "
+                      "Remove the energy attribute from the BEAM command — "
+                      "particle momenta are read from the file.");
+            }
+        } else {
+            if (!beam->hasExplicitEnergy()) {
+                throw OpalException(
+                    "TrackRun::setupDistributionsAndSamplers()",
+                    "The energy hasn't been set. "
+                    "Set either \"GAMMA\", \"ENERGY\" or \"PC\" on the BEAM command.");
+            }
+        }
+
         distrs_m.push_back(distRaw);
 
         // Build a sampler instance for this emission source.


### PR DESCRIPTION
As described in #363, when using the `FROMFILE` option for the distribution, the `PC`/`GAMMA`/`ENERGY` options in the input file is quietly ignored. This could lead to confusion in the future. 

This PR removes this possibility. 
closes #363

<!-- obsidian --><h2 data-heading="Files changed">Files changed</h2>

File | Change
-- | --
`src/Structure/Beam.h `| Added `hasExplicitEnergy()` declaration
`src/Structure/Beam.cpp` | Added `hasExplicitEnergy()`, removed energy check from `execute()`
`src/Track/TrackRun.cpp` | Added `FROMFILE` vs energy validation in `setupDistributionsAndSamplers()`


```mermaid
flowchart TD
    subgraph Before["Before (Beam::execute)"]
        direction TB
        B1["Beam::execute()"] --> B2{"PC or ENERGY\nor GAMMA set?"}
        B2 -->|No| B3["ERROR: energy not set"]
        B2 -->|Yes| B4["OK — no distribution\ncontext available"]
        
        style B3 fill:#dc3545,color:#fff
        style B4 fill:#6c757d,color:#fff
    end

    subgraph After["After (TrackRun::setupDistributionsAndSamplers)"]
        direction TB
        A1["setDistType() called\non Distribution"] --> A2{"Distribution type?"}
        A2 -->|FROMFILE| A3{"beam->hasExplicit\nEnergy()?"}
        A2 -->|GAUSS / other| A4{"beam->hasExplicit\nEnergy()?"}
        
        A3 -->|Yes| A5["ERROR: FROMFILE cannot\nbe combined with\nPC/ENERGY/GAMMA"]
        A3 -->|No| A6["OK — momenta\ncome from file"]
        
        A4 -->|Yes| A7["OK — energy sets\nmean pz"]
        A4 -->|No| A8["ERROR: energy\nnot set"]

        style A5 fill:#dc3545,color:#fff
        style A8 fill:#dc3545,color:#fff
        style A6 fill:#2d6a4f,color:#fff
        style A7 fill:#2d6a4f,color:#fff
    end
```

The regression tests need to be updated to match this new requirement: https://github.com/OPALX-project/regression-tests-x/pull/27/

## Result:
Trying to specify `PC` and `FROMFILE` at the same time gives:
```
Error> 
Error> *** User error detected by function "TrackRun::setupDistributionsAndSamplers()"
Error>     FROMFILE distribution "DIST1_FF" cannot be combined with PC/ENERGY/GAMMA on the BEAM. Remove the energy attribute from the BEAM command — particle momenta are read from the file.
```