### PR TITLE
Conditional `itsAttr[CHARGE]` and `itsAttr[MASS]` writing

### DIFF
--- a/src/Structure/Beam.cpp
+++ b/src/Structure/Beam.cpp
@@ -256,8 +256,12 @@ void Beam::update() {
     if (itsAttr[PARTICLE]) {
         std::string pName  = getParticleName();
         ParticleType pType = ParticleProperties::getParticleType(pName);
-        Attributes::setReal(itsAttr[MASS], ParticleProperties::getParticleMass(pType));
-        Attributes::setReal(itsAttr[CHARGE], ParticleProperties::getParticleCharge(pType));
+        if (!itsAttr[MASS]) {
+            Attributes::setReal(itsAttr[MASS], ParticleProperties::getParticleMass(pType));
+        }
+        if (!itsAttr[CHARGE]) {
+            Attributes::setReal(itsAttr[CHARGE], ParticleProperties::getParticleCharge(pType));
+        }
     }
 
     if (isPhoton()) {


### PR DESCRIPTION
This PR addresses the issue #365 . 
It is solved by gating the write with the condition that the attributes may not already be set. 

```c++
    if (itsAttr[PARTICLE]) {
        std::string pName  = getParticleName();
        ParticleType pType = ParticleProperties::getParticleType(pName);
        if (!itsAttr[MASS]) {
            Attributes::setReal(itsAttr[MASS], ParticleProperties::getParticleMass(pType));
        }
        if (!itsAttr[CHARGE]) {
            Attributes::setReal(itsAttr[CHARGE], ParticleProperties::getParticleCharge(pType));
        }
    }
```
Passes all regression tests on CPU and GPU.

Here are the rms_x and rms_y plots of the fodo test case where I changed the `CHARGE`from -1 to +1. 
Reference, in this case, referrs to `CHARGE` -1 and simulation to `CHARGE` +1.

<img width="1094" height="434" alt="image" src="https://github.com/user-attachments/assets/71592095-e08e-49fd-afd8-c6d8e41ba851" />

<img width="1094" height="434" alt="image" src="https://github.com/user-attachments/assets/2baf4cbb-b51d-45bd-b1bc-14deae307948" />

closes #365 
