### PR TITLE
replace BCURRENT and BFREQ with BCHARGE

### DIFF
--- a/src/Structure/Beam.cpp
+++ b/src/Structure/Beam.cpp
@@ -45,8 +45,9 @@ namespace {
         ENERGY,    // The particle energy in GeV
         PC,        // The particle momentum in GeV/c
         GAMMA,     // ENERGY / MASS
-        BCURRENT,  // Beam current in A
-        BFREQ,     // Beam frequency in MHz
+        BCURRENT,  // Legacy, unused in OPALX (holdover from OPALCycl)
+        BFREQ,     // Legacy, unused in OPALX (holdover from OPALCycl)
+        BCHARGE,   // Bunch charge in C
         NPART,     // Number of particles per bunch
         SOURCES,   // Name of EMISSIONSOURCELIST
         SIZE
@@ -74,9 +75,13 @@ Beam::Beam()
 
     itsAttr[GAMMA] = Attributes::makeReal("GAMMA", "ENERGY / MASS");
 
-    itsAttr[BCURRENT] = Attributes::makeReal("BCURRENT", "Beam current [A] (all bunches)");
+    itsAttr[BCURRENT] = Attributes::makeReal(
+        "BCURRENT", "Legacy, unused in OPALX. Use BCHARGE instead.");
 
-    itsAttr[BFREQ] = Attributes::makeReal("BFREQ", "Beam frequency [MHz] (all bunches)");
+    itsAttr[BFREQ] = Attributes::makeReal(
+        "BFREQ", "Legacy, unused in OPALX. Use BCHARGE instead.");
+
+    itsAttr[BCHARGE] = Attributes::makeReal("BCHARGE", "Bunch charge [C]");
 
     itsAttr[NPART] = Attributes::makeReal("NPART", "Number of particles in bunch");
 
@@ -141,6 +146,13 @@ void Beam::execute() {
             throw OpalException("Beam::execute()",
                                 "\"SOURCES\" is not allowed for PARTICLE=PHOTON.");
         }
+    }
+
+    if (itsAttr[BCURRENT] || itsAttr[BFREQ]) {
+        throw OpalException(
+            "Beam::execute()",
+            "\"BCURRENT\" and \"BFREQ\" are no longer used in OPALX. "
+            "Use \"BCHARGE\" [C] to specify the bunch charge directly.");
     }
 
     update();
@@ -215,6 +227,10 @@ double Beam::getCurrent() const {
     return Attributes::getReal(itsAttr[BCURRENT]);
 }
 
+double Beam::getBunchCharge() const {
+    return Attributes::getReal(itsAttr[BCHARGE]);
+}
+
 double Beam::getCharge() const {
     return Attributes::getReal(itsAttr[CHARGE]);
 }
@@ -244,8 +260,7 @@ bool Beam::hasExplicitEnergy() const {
 }
 
 double Beam::getChargePerParticle() const {
-    return std::copysign(1.0, getCharge()) * getCurrent() / (getFrequency() * Units::MHz2Hz) 
-           / getNumberOfParticles();
+    return std::copysign(1.0, getCharge()) * getBunchCharge() / getNumberOfParticles();
 }
 
 double Beam::getMassPerParticle() const {
@@ -315,8 +330,7 @@ void Beam::print(std::ostream& os) const {
        << "* CHARGE      " << (charge > 0 ? '+' : '-') << "e * " << std::abs(charge) << " \n"
        << "* MOMENTUM    " << reference.getP() << " [eV/c]\n"
        << "* MOMENTUM    " << Attributes::getReal(itsAttr[PC]) << " [GeV/c]\n"
-       << "* CURRENT     " << Attributes::getReal(itsAttr[BCURRENT]) << " [A]\n"
-       << "* FREQUENCY   " << Attributes::getReal(itsAttr[BFREQ]) << " [MHz]\n"
+       << "* BCHARGE     " << Attributes::getReal(itsAttr[BCHARGE]) << " [C]\n"
        << "* NPART       " << Attributes::getReal(itsAttr[NPART]) << '\n';
     os << "* ********************************************************************************** "
        << std::endl;

--- a/src/Structure/Beam.h
+++ b/src/Structure/Beam.h
@@ -55,8 +55,11 @@ public:
     /// Return the embedded CLASSIC PartData.
     const PartData& getReference() const;
 
-    /// Return the beam current in A
+    /// Return the beam current in A (legacy; no longer used in OPALX)
     double getCurrent() const;
+
+    /// Return the bunch charge in C
+    double getBunchCharge() const;
 
     /// Return the charge number in elementary charge
     double getCharge() const;


### PR DESCRIPTION
### Summary
This PR addresses the issue specified in #369. 
`BCURRENT` and `BFREQ` are still attributes but disabled for now.  Instead `BCHARGE` is used directly. 
This closes #369 and needs to be accompanied by an [update of the regression tests](https://github.com/OPALX-project/regression-tests-x/pull/32).

### Testing
The updated [regression tests](https://github.com/OPALX-project/regression-tests-x/tree/change-beam-attributes) pass both on CPU and GPU.