### PR TITLE
Rename NPART to NALLOC

### DIFF
--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -712,7 +712,7 @@ void ParallelTracker::emitFromEmissionSources(double t, double dt) {
         // itsBunch_m->bunchUpdate();
 
         // Sanity guard: the total number of macroparticles in the bunch must
-        // never exceed the globally configured BEAM::NPART value. Overshooting
+        // never exceed the globally configured BEAM::NALLOC value. Overshooting
         // this limit would trigger internal reallocations in the particle
         // container and silently drop already-tracked particles/delete their data in the particle
         // attributes. This is only a check for the number of local particles.

--- a/src/Distribution/FlatTop.cpp
+++ b/src/Distribution/FlatTop.cpp
@@ -361,7 +361,7 @@ void FlatTop::allocateParticles(size_t numberOfParticles){
     // Initial allocation is now handled centrally in TrackRun / PartBunch via the
     // bunch's total particle count. Here we only record the desired total number
     // of particles for this distribution. Actual per-step emission will append
-    // new particles using pc_m->create(nNew), guarded by a global BEAM::NPART
+    // new particles using pc_m->create(nNew), guarded by a global BEAM::NALLOC
     // limit in ParallelTracker.
 }
 

--- a/src/Structure/Beam.cpp
+++ b/src/Structure/Beam.cpp
@@ -48,7 +48,7 @@ namespace {
         BCURRENT,  // Legacy, unused in OPALX (holdover from OPALCycl)
         BFREQ,     // Legacy, unused in OPALX (holdover from OPALCycl)
         BCHARGE,   // Bunch charge in C
-        NPART,     // Number of particles per bunch
+        NALLOC,    // Allocation size (macroparticles) for this beam
         SOURCES,   // Name of EMISSIONSOURCELIST
         SIZE
     };
@@ -83,7 +83,7 @@ Beam::Beam()
 
     itsAttr[BCHARGE] = Attributes::makeReal("BCHARGE", "Bunch charge [C]");
 
-    itsAttr[NPART] = Attributes::makeReal("NPART", "Number of particles in bunch");
+    itsAttr[NALLOC] = Attributes::makeReal("NALLOC", "Allocation size (macroparticles) for this beam");
 
     itsAttr[SOURCES] =
         Attributes::makeString("SOURCES", "Name of the emission sources list (EMISSIONSOURCELIST).");
@@ -164,8 +164,8 @@ void Beam::execute() {
             "Set either \"PARTICLE\" or \"MASS\" and \"CHARGE\".");
     }
 
-    if (!(itsAttr[NPART])) {
-        throw OpalException("Beam::execute()", "\"NPART\" must be set.");
+    if (!(itsAttr[NALLOC])) {
+        throw OpalException("Beam::execute()", "\"NALLOC\" must be set.");
     }
 
     if (photon) {
@@ -207,13 +207,13 @@ Beam* Beam::find(const std::string& name) {
     return beam;
 }
 
-size_t Beam::getNumberOfParticles() const {
-    if (Attributes::getReal(itsAttr[NPART]) > 0) {
-        return (size_t)Attributes::getReal(itsAttr[NPART]);
+size_t Beam::getNumAlloc() const {
+    if (Attributes::getReal(itsAttr[NALLOC]) > 0) {
+        return (size_t)Attributes::getReal(itsAttr[NALLOC]);
     } else {
         throw OpalException(
-            "Beam::getNumberOfParticles()",
-            "Wrong number of particles in beam!. \"NPART\" must be positive");
+            "Beam::getNumAlloc()",
+            "Wrong allocation size for beam! \"NALLOC\" must be positive");
     }
 }
 
@@ -260,7 +260,7 @@ bool Beam::hasExplicitEnergy() const {
 }
 
 double Beam::getChargePerParticle() const {
-    return std::copysign(1.0, getCharge()) * getBunchCharge() / getNumberOfParticles();
+    return std::copysign(1.0, getCharge()) * getBunchCharge() / getNumAlloc();
 }
 
 double Beam::getMassPerParticle() const {
@@ -331,7 +331,7 @@ void Beam::print(std::ostream& os) const {
        << "* MOMENTUM    " << reference.getP() << " [eV/c]\n"
        << "* MOMENTUM    " << Attributes::getReal(itsAttr[PC]) << " [GeV/c]\n"
        << "* BCHARGE     " << Attributes::getReal(itsAttr[BCHARGE]) << " [C]\n"
-       << "* NPART       " << Attributes::getReal(itsAttr[NPART]) << '\n';
+       << "* NALLOC      " << Attributes::getReal(itsAttr[NALLOC]) << '\n';
     os << "* ********************************************************************************** "
        << std::endl;
 }

--- a/src/Structure/Beam.h
+++ b/src/Structure/Beam.h
@@ -49,8 +49,8 @@ public:
     /// Find named BEAM.
     static Beam* find(const std::string& name);
 
-    /// Return the number of (macro)particles
-    size_t getNumberOfParticles() const;
+    /// Return the allocation size (macroparticles) for this beam
+    size_t getNumAlloc() const;
 
     /// Return the embedded CLASSIC PartData.
     const PartData& getReference() const;

--- a/src/Track/TrackRun.cpp
+++ b/src/Track/TrackRun.cpp
@@ -316,7 +316,7 @@ void TrackRun::execute() {
     std::vector<size_t> totalParticlesPerBeam(beams.size());
     for (size_t i = 0; i < beams.size(); ++i) {
         Beam* b = beams[i];
-        totalParticlesPerBeam[i] = computeTotalParticlesForBunch(b, emissionSourcesLists[i]);
+        totalParticlesPerBeam[i] = computeTotalAllocationForBunch(b, emissionSourcesLists[i]);
     }
 
     // Create PartBunch (PIC Manager) with multiple particle containers
@@ -498,10 +498,10 @@ void TrackRun::setupBoundaryGeometry() {
     }
 }
 
-size_t TrackRun::computeTotalParticlesForBunch(
+size_t TrackRun::computeTotalAllocationForBunch(
     Beam* beam,
     const std::vector<EmissionSource*>& sources) const {
-    size_t beamNumParticles = beam->getNumberOfParticles();
+    size_t beamAllocSize = beam->getNumAlloc();
 
     size_t totalFromDists = 0;
     for (EmissionSource* src : sources) {
@@ -512,18 +512,19 @@ size_t TrackRun::computeTotalParticlesForBunch(
     if (totalFromDists > 0) {
         *gmsg << level3
               << "* Sum of per-distribution NPARTDIST over all emission sources = "
-              << totalFromDists << ", BEAM::NPART = " << beamNumParticles << endl;
-        if (totalFromDists != beamNumParticles) {
+              << totalFromDists << ", BEAM::NALLOC = " << beamAllocSize << endl;
+        if (totalFromDists > beamAllocSize) {
             *gmsg << level1
                   << "* WARNING: Sum of NPARTDIST over all distributions ("
                   << totalFromDists
-                  << ") does not match BEAM::NPART (" << beamNumParticles
-                  << "). Macro-charge per particle still derived from BEAM." << endl;
+                  << ") exceeds BEAM::NALLOC (" << beamAllocSize
+                  << "). Allocation baseline may be insufficient; "
+                  << "macro-charge per particle is still derived from BEAM::NALLOC." << endl;
         }
         return totalFromDists;
     }
 
-    return beamNumParticles;
+    return beamAllocSize;
 }
 
 void TrackRun::setupDistributionsAndSamplers(

--- a/src/Track/TrackRun.h
+++ b/src/Track/TrackRun.h
@@ -86,9 +86,9 @@ private:
         size_t index=0
     );
 
-    /// Compute total number of macroparticles for the bunch from BEAM::NPART and
+    /// Compute total number of macroparticles for the bunch from BEAM::NALLOC and
     /// optional per-distribution NPARTDIST values on the emission sources.
-    size_t computeTotalParticlesForBunch(
+    size_t computeTotalAllocationForBunch(
         Beam* beam,
         const std::vector<EmissionSource*>& sources) const;
 

--- a/unit_tests/Structure/TestBeam.cpp
+++ b/unit_tests/Structure/TestBeam.cpp
@@ -37,14 +37,14 @@ protected:
         Attributes::setString(*beam.findAttribute("SOURCES"), value);
     }
 
-    void setNPART(Beam& beam, double value) {
-        Attributes::setReal(*beam.findAttribute("NPART"), value);
+    void setNALLOC(Beam& beam, double value) {
+        Attributes::setReal(*beam.findAttribute("NALLOC"), value);
     }
 
     void makeValidPhotonBeam(Beam& beam) {
         setParticle(beam, "PHOTON");
         setEnergy(beam, 5.0);
-        setNPART(beam, 1.0);
+        setNALLOC(beam, 1.0);
     }
 };
 
@@ -68,7 +68,7 @@ TEST_F(BeamPhotonTest, PhotonBeamAcceptsEnergyOnlyDefinition) {
 TEST_F(BeamPhotonTest, PhotonBeamRequiresEnergy) {
     Beam beam;
     setParticle(beam, "PHOTON");
-    setNPART(beam, 1.0);
+    setNALLOC(beam, 1.0);
 
     EXPECT_THROW(beam.execute(), OpalException);
 }


### PR DESCRIPTION
### Context

The `BEAM` object's `NPART` attribute is misleadingly named. In practice it does **not** set the number of simulated particles — that comes from the `DISTRIBUTION`'s `NPARTDIST`. Instead, `NPART` in BEAM is used only to:
1. Size the per-rank allocation buffer in `PartBunch::PartBunch`, passed via `totalParticlesPerBeam`.
2. Compute the macro-charge/macro-mass via `Beam::getChargePerParticle()` / `getMassPerParticle()`.

This PR is the first step in addressing issue #371. The `NPART` is renamed to `NALLOC` which is used to determine the memory that needs to be allocated. The creation of actual particles is left to the distribution classes and determined by the `NPARTDIST` attribute.

### Testing
With the [updated inputfiles](https://github.com/OPALX-project/regression-tests-x/pull/33) this is passing all regression and unit tests on CPU and GPU.