### PR TITLE
 Changed:

### DIFF
--- a/src/AbsBeamline/BeamlineVisitor.h
+++ b/src/AbsBeamline/BeamlineVisitor.h
@@ -43,14 +43,17 @@ class FlaggedElmPtr;
 
 // Specific element classes interacting with a BeamlineVisitor
 class Drift;
+class Laser;
 class Marker;
 class Monitor;
 class Multipole;
 class MultipoleT;
+class RBend;
 class RFCavity;
 class VariableRFCavity;
 class TravelingWave;
 class Ring;
+class SBend;
 class Solenoid;
 class ScalingFFAMagnet;
 class Offset;
@@ -77,6 +80,9 @@ public:
     /// Apply the algorithm to a drift space.
     virtual void visitDrift(const Drift&) = 0;
 
+    /// Apply the algorithm to a laser element.
+    virtual void visitLaser(const Laser&) = 0;
+
     /// Apply the algorithm to a FlaggedElmPtr.
     virtual void visitFlaggedElmPtr(const FlaggedElmPtr&) = 0;
 
@@ -92,6 +98,9 @@ public:
     /// Apply the algorithm to an arbitrary multipole.
     virtual void visitMultipoleT(const MultipoleT&) = 0;
 
+    /// Apply the algorithm to a rectangular bend.
+    virtual void visitRBend(const RBend&) = 0;
+
     /// Apply the algorithm to a RF cavity.
     virtual void visitRFCavity(const RFCavity&) = 0;
 
@@ -102,6 +111,9 @@ public:
 
     /// Apply the algorithm to a Ring element.
     virtual void visitRing(const Ring&) = 0;
+
+    /// Apply the algorithm to a sector bend.
+    virtual void visitSBend(const SBend&) = 0;
 
     /// Apply the algorithm to a Solenoid element.
     virtual void visitSolenoid(const Solenoid&) = 0;

--- a/src/AbsBeamline/Laser.cpp
+++ b/src/AbsBeamline/Laser.cpp
@@ -29,7 +29,7 @@ Laser::Laser(const Laser& right)
 
 Laser::~Laser() {}
 
-void Laser::accept(BeamlineVisitor& visitor) const { visitor.visitComponent(*this); }
+void Laser::accept(BeamlineVisitor& visitor) const { visitor.visitLaser(*this); }
 
 void Laser::initialise(PartBunch_t* bunch, double& startField, double& endField) {
     endField       = startField + getElementLength();

--- a/src/AbsBeamline/Laser.h
+++ b/src/AbsBeamline/Laser.h
@@ -36,7 +36,7 @@ public:
     /** @brief Destroy the laser element. */
     ~Laser() override;
 
-    /** @brief Accept a beamline visitor through the generic component interface. */
+    /** @brief Accept a beamline visitor through the laser-specific interface. */
     void accept(BeamlineVisitor&) const override;
 
     /**

--- a/src/AbsBeamline/RBend.cpp
+++ b/src/AbsBeamline/RBend.cpp
@@ -10,7 +10,7 @@ RBend::RBend(const std::string& name) : BendBase(name) {}
 
 RBend::~RBend() = default;
 
-void RBend::accept(BeamlineVisitor& visitor) const { visitor.visitComponent(*this); }
+void RBend::accept(BeamlineVisitor& visitor) const { visitor.visitRBend(*this); }
 
 ElementType RBend::getType() const { return ElementType::RBEND; }
 

--- a/src/AbsBeamline/SBend.cpp
+++ b/src/AbsBeamline/SBend.cpp
@@ -10,7 +10,7 @@ SBend::SBend(const std::string& name) : BendBase(name) {}
 
 SBend::~SBend() = default;
 
-void SBend::accept(BeamlineVisitor& visitor) const { visitor.visitComponent(*this); }
+void SBend::accept(BeamlineVisitor& visitor) const { visitor.visitSBend(*this); }
 
 ElementType SBend::getType() const { return ElementType::SBEND; }
 

--- a/src/AbsBeamline/SpecificElementVisitor.h
+++ b/src/AbsBeamline/SpecificElementVisitor.h
@@ -25,21 +25,22 @@
 #include "AbsBeamline/ConstantEFieldCavity.h"
 #include "AbsBeamline/Corrector.h"
 #include "AbsBeamline/Cyclotron.h"
-#include "AbsBeamline/Drift.h"
 #include "AbsBeamline/Degrader.h"
+#include "AbsBeamline/Drift.h"
 #include "AbsBeamline/ElementBase.h"
 #include "AbsBeamline/FlexibleCollimator.h"
+#include "AbsBeamline/Laser.h"
 #include "AbsBeamline/Marker.h"
 #include "AbsBeamline/Monitor.h"
 #include "AbsBeamline/Multipole.h"
 #include "AbsBeamline/MultipoleT.h"
-#include "AbsBeamline/MultipoleTStraight.h"
 #include "AbsBeamline/MultipoleTCurvedConstRadius.h"
 #include "AbsBeamline/MultipoleTCurvedVarRadius.h"
+#include "AbsBeamline/MultipoleTStraight.h"
 #include "AbsBeamline/Probe.h"
 #include "AbsBeamline/RBend.h"
-#include "AbsBeamline/Ring.h"
 #include "AbsBeamline/RFCavity.h"
+#include "AbsBeamline/Ring.h"
 #include "AbsBeamline/SBend.h"
 #include "AbsBeamline/SBend3D.h"
 #include "AbsBeamline/ScalingFFAMagnet.h"
@@ -64,135 +65,134 @@ template <class ELEM1, class ELEM2>
 struct CastsTrait {
     typedef std::list<const ELEM1*> ElementList_t;
 
-    static void apply(ElementList_t &, const ELEM2 &)
-    { }
+    static void apply(ElementList_t&, const ELEM2&) {}
 };
 
 template <class ELEM>
-struct CastsTrait<ELEM,ELEM> {
+struct CastsTrait<ELEM, ELEM> {
     typedef std::list<const ELEM*> ElementList_t;
 
-    static void apply(ElementList_t &allElements, const ELEM &element)
-    {
+    static void apply(ElementList_t& allElements, const ELEM& element) {
         allElements.push_back(dynamic_cast<const ELEM*>(&element));
     }
 };
 
 template <class ELEM>
-class SpecificElementVisitor: public BeamlineVisitor {
+class SpecificElementVisitor : public BeamlineVisitor {
 public:
-    SpecificElementVisitor(const Beamline &beamline);
+    SpecificElementVisitor(const Beamline& beamline);
 
     virtual void execute();
 
     /// Apply the algorithm to a beam line.
-    virtual void visitBeamline(const Beamline &);
-    
+    virtual void visitBeamline(const Beamline&);
+
     /// Apply the algorithm to a collimator.
-    virtual void visitCCollimator(const CCollimator &);
+    virtual void visitCCollimator(const CCollimator&);
 
     /// Apply the algorithm to an arbitrary component.
-    virtual void visitComponent(const Component &);
+    virtual void visitComponent(const Component&);
 
     /// Apply the algorithm to a closed orbit corrector.
-    virtual void visitCorrector(const Corrector &);
+    virtual void visitCorrector(const Corrector&);
 
     /// Apply the algorithm to an cyclotron
-    virtual void visitCyclotron(const Cyclotron &);
+    virtual void visitCyclotron(const Cyclotron&);
 
     /// Apply the algorithm to a degrader.
-    virtual void visitDegrader(const Degrader &);
+    virtual void visitDegrader(const Degrader&);
 
     /// Apply the algorithm to a constant E-field cavity element.
-    virtual void visitConstantEFieldCavity(const ConstantEFieldCavity &);
+    virtual void visitConstantEFieldCavity(const ConstantEFieldCavity&);
 
     /// Apply the algorithm to a drift.
-    virtual void visitDrift(const Drift &);
+    virtual void visitDrift(const Drift&);
+
+    /// Apply the algorithm to a laser.
+    virtual void visitLaser(const Laser&);
 
     /// Apply the algorithm to a FlaggedElmPtr.
-    virtual void visitFlaggedElmPtr(const FlaggedElmPtr &);
+    virtual void visitFlaggedElmPtr(const FlaggedElmPtr&);
 
     /// Apply the algorithm to a flexible collimator
-    virtual void visitFlexibleCollimator(const FlexibleCollimator &);
+    virtual void visitFlexibleCollimator(const FlexibleCollimator&);
 
     /// Apply the algorithm to a marker.
-    virtual void visitMarker(const Marker &);
+    virtual void visitMarker(const Marker&);
 
     /// Apply the algorithm to a beam position monitor.
-    virtual void visitMonitor(const Monitor &);
+    virtual void visitMonitor(const Monitor&);
 
     /// Apply the algorithm to a multipole.
-    virtual void visitMultipole(const Multipole &);
+    virtual void visitMultipole(const Multipole&);
 
     /// Apply the algorithm to an arbitrary multipole.
-    virtual void visitMultipoleT(const MultipoleT &);
+    virtual void visitMultipoleT(const MultipoleT&);
 
     /// Apply the algorithm to an arbitrary straight multipole.
-    virtual void visitMultipoleTStraight(const MultipoleTStraight &);
+    virtual void visitMultipoleTStraight(const MultipoleTStraight&);
 
     /// Apply the algorithm to an arbitrary curved multipole of constant radius.
-    virtual void visitMultipoleTCurvedConstRadius(const MultipoleTCurvedConstRadius &);
+    virtual void visitMultipoleTCurvedConstRadius(const MultipoleTCurvedConstRadius&);
 
     /// Apply the algorithm to an arbitrary curved multipole of variable radius.
-    virtual void visitMultipoleTCurvedVarRadius(const MultipoleTCurvedVarRadius &);
+    virtual void visitMultipoleTCurvedVarRadius(const MultipoleTCurvedVarRadius&);
 
     /// Apply the algorithm to a probe.
-    virtual void visitProbe(const Probe &prob);
+    virtual void visitProbe(const Probe& prob);
 
     /// Apply the algorithm to a rectangular bend.
-    virtual void visitRBend(const RBend &);
+    virtual void visitRBend(const RBend&);
 
     /// Apply the algorithm to a rectangular bend.
-    virtual void visitRBend3D(const RBend3D &);
+    virtual void visitRBend3D(const RBend3D&);
 
     /// Apply the algorithm to a RF cavity.
-    virtual void visitRFCavity(const RFCavity &);
+    virtual void visitRFCavity(const RFCavity&);
 
     /// Apply the algorithm to a ring.
-    virtual void visitRing(const Ring &);
+    virtual void visitRing(const Ring&);
 
     /// Apply the algorithm to a sector bend.
-    virtual void visitSBend(const SBend &);
+    virtual void visitSBend(const SBend&);
 
     /// Apply the algorithm to a sector bend with 3D field map.
-    virtual void visitSBend3D(const SBend3D &);
+    virtual void visitSBend3D(const SBend3D&);
 
     /// Apply the algorithm to a scaling FFA magnet.
-    virtual void visitScalingFFAMagnet(const ScalingFFAMagnet &);
+    virtual void visitScalingFFAMagnet(const ScalingFFAMagnet&);
 
     /// Apply the algorithm to a septum.
-    virtual void visitSeptum(const Septum &);
+    virtual void visitSeptum(const Septum&);
 
     /// Apply the algorithm to a solenoid.
-    virtual void visitSolenoid(const Solenoid &);
+    virtual void visitSolenoid(const Solenoid&);
 
     /// Apply the algorithm to a source.
-    virtual void visitSource(const Source &);
+    virtual void visitSource(const Source&);
 
-   /// Apply the algorithm to a particle stripper.
-    virtual void visitStripper(const Stripper &);
+    /// Apply the algorithm to a particle stripper.
+    virtual void visitStripper(const Stripper&);
 
     /// Apply the algorithm to a traveling wave
-    virtual void visitTravelingWave(const TravelingWave &);
+    virtual void visitTravelingWave(const TravelingWave&);
 
 #ifdef ENABLE_OPAL_FEL
     /// Apply the algorithm to an undulator.
-    virtual void visitUndulator(const Undulator &);
+    virtual void visitUndulator(const Undulator&);
 #endif
 
     /// Apply the algorithm to a vacuum space.
-    virtual void visitVacuum(const Vacuum &);
+    virtual void visitVacuum(const Vacuum&);
 
     /// Apply the algorithm to a variable RF cavity.
-    virtual void visitVariableRFCavity(const VariableRFCavity &vcav);
+    virtual void visitVariableRFCavity(const VariableRFCavity& vcav);
 
     /// Apply the algorithm to a variable RF cavity with Fringe Field..
-    virtual void visitVariableRFCavityFringeField
-                                      (const VariableRFCavityFringeField &vcav);
+    virtual void visitVariableRFCavityFringeField(const VariableRFCavityFringeField& vcav);
 
     /// Apply the algorithm to a vertical FFA magnet.
-    virtual void visitVerticalFFAMagnet(const VerticalFFAMagnet &);
-
+    virtual void visitVerticalFFAMagnet(const VerticalFFAMagnet&);
 
     size_t size() const;
 
@@ -216,231 +216,235 @@ private:
     ElementList_t allElementsOfTypeE;
 };
 
-template<class ELEM>
-SpecificElementVisitor<ELEM>::SpecificElementVisitor(const Beamline &beamline):
-    BeamlineVisitor(),
-    allElementsOfTypeE()
-{
+template <class ELEM>
+SpecificElementVisitor<ELEM>::SpecificElementVisitor(const Beamline& beamline)
+    : BeamlineVisitor(), allElementsOfTypeE() {
     beamline.iterate(*this, false);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::execute()
-{ }
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::execute() {}
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitBeamline(const Beamline &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitBeamline(const Beamline& element) {
     element.iterate(*this, false);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitCCollimator(const CCollimator &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitCCollimator(const CCollimator& element) {
     CastsTrait<ELEM, CCollimator>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitComponent(const Component &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitComponent(const Component& element) {
     CastsTrait<ELEM, Component>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitCorrector(const Corrector &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitCorrector(const Corrector& element) {
     CastsTrait<ELEM, Corrector>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitCyclotron(const Cyclotron &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitCyclotron(const Cyclotron& element) {
     CastsTrait<ELEM, Cyclotron>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitDegrader(const Degrader &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitDegrader(const Degrader& element) {
     CastsTrait<ELEM, Degrader>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitConstantEFieldCavity(const ConstantEFieldCavity &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitConstantEFieldCavity(const ConstantEFieldCavity& element) {
     CastsTrait<ELEM, ConstantEFieldCavity>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitDrift(const Drift &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitDrift(const Drift& element) {
     CastsTrait<ELEM, Drift>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitFlaggedElmPtr(const FlaggedElmPtr &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitLaser(const Laser& element) {
+    CastsTrait<ELEM, Laser>::apply(allElementsOfTypeE, element);
+}
+
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitFlaggedElmPtr(const FlaggedElmPtr& element) {
     const ElementBase* wrappedElement = element.getElement();
     wrappedElement->accept(*this);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitFlexibleCollimator(const FlexibleCollimator &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitFlexibleCollimator(const FlexibleCollimator& element) {
     CastsTrait<ELEM, FlexibleCollimator>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMarker(const Marker &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMarker(const Marker& element) {
     CastsTrait<ELEM, Marker>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMonitor(const Monitor &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMonitor(const Monitor& element) {
     CastsTrait<ELEM, Monitor>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMultipole(const Multipole &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMultipole(const Multipole& element) {
     CastsTrait<ELEM, Multipole>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMultipoleT(const MultipoleT &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMultipoleT(const MultipoleT& element) {
     CastsTrait<ELEM, MultipoleT>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMultipoleTStraight(const MultipoleTStraight &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMultipoleTStraight(const MultipoleTStraight& element) {
     CastsTrait<ELEM, MultipoleTStraight>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMultipoleTCurvedConstRadius(const MultipoleTCurvedConstRadius &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMultipoleTCurvedConstRadius(
+        const MultipoleTCurvedConstRadius& element) {
     CastsTrait<ELEM, MultipoleTCurvedConstRadius>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitMultipoleTCurvedVarRadius(const MultipoleTCurvedVarRadius &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitMultipoleTCurvedVarRadius(
+        const MultipoleTCurvedVarRadius& element) {
     CastsTrait<ELEM, MultipoleTCurvedVarRadius>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitProbe(const Probe &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitProbe(const Probe& element) {
     CastsTrait<ELEM, Probe>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitRBend(const RBend &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitRBend(const RBend& element) {
     CastsTrait<ELEM, RBend>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitRBend3D(const RBend3D &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitRBend3D(const RBend3D& element) {
     CastsTrait<ELEM, RBend3D>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitRFCavity(const RFCavity &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitRFCavity(const RFCavity& element) {
     CastsTrait<ELEM, RFCavity>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitRing(const Ring &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitRing(const Ring& element) {
     CastsTrait<ELEM, Ring>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitSBend(const SBend &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitSBend(const SBend& element) {
     CastsTrait<ELEM, SBend>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitSBend3D(const SBend3D &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitSBend3D(const SBend3D& element) {
     CastsTrait<ELEM, SBend3D>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitScalingFFAMagnet(const ScalingFFAMagnet &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitScalingFFAMagnet(const ScalingFFAMagnet& element) {
     CastsTrait<ELEM, ScalingFFAMagnet>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitSeptum(const Septum &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitSeptum(const Septum& element) {
     CastsTrait<ELEM, Septum>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitSolenoid(const Solenoid &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitSolenoid(const Solenoid& element) {
     CastsTrait<ELEM, Solenoid>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitSource(const Source &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitSource(const Source& element) {
     CastsTrait<ELEM, Source>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitStripper(const Stripper &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitStripper(const Stripper& element) {
     CastsTrait<ELEM, Stripper>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitTravelingWave(const TravelingWave &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitTravelingWave(const TravelingWave& element) {
     CastsTrait<ELEM, TravelingWave>::apply(allElementsOfTypeE, element);
 }
 
 #ifdef ENABLE_OPAL_FEL
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitUndulator(const Undulator &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitUndulator(const Undulator& element) {
     CastsTrait<ELEM, Undulator>::apply(allElementsOfTypeE, element);
 }
 #endif
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitVacuum(const Vacuum &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitVacuum(const Vacuum& element) {
     CastsTrait<ELEM, Vacuum>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitVariableRFCavity
-                                             (const VariableRFCavity &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitVariableRFCavity(const VariableRFCavity& element) {
     CastsTrait<ELEM, VariableRFCavity>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitVariableRFCavityFringeField
-                                  (const VariableRFCavityFringeField &element) {
-    CastsTrait<ELEM, VariableRFCavityFringeField>::apply(allElementsOfTypeE,
-                                                         element);
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitVariableRFCavityFringeField(
+        const VariableRFCavityFringeField& element) {
+    CastsTrait<ELEM, VariableRFCavityFringeField>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-void SpecificElementVisitor<ELEM>::visitVerticalFFAMagnet(const VerticalFFAMagnet &element) {
+template <class ELEM>
+void SpecificElementVisitor<ELEM>::visitVerticalFFAMagnet(const VerticalFFAMagnet& element) {
     CastsTrait<ELEM, VerticalFFAMagnet>::apply(allElementsOfTypeE, element);
 }
 
-template<class ELEM>
-size_t SpecificElementVisitor<ELEM>::size() const{
+template <class ELEM>
+size_t SpecificElementVisitor<ELEM>::size() const {
     return allElementsOfTypeE.size();
 }
 
-template<class ELEM>
-typename SpecificElementVisitor<ELEM>::iterator_t SpecificElementVisitor<ELEM>::begin(){
+template <class ELEM>
+typename SpecificElementVisitor<ELEM>::iterator_t SpecificElementVisitor<ELEM>::begin() {
     return allElementsOfTypeE.begin();
 }
 
-template<class ELEM>
-typename SpecificElementVisitor<ELEM>::const_iterator_t SpecificElementVisitor<ELEM>::begin() const{
+template <class ELEM>
+typename SpecificElementVisitor<ELEM>::const_iterator_t SpecificElementVisitor<ELEM>::begin()
+        const {
     return allElementsOfTypeE.begin();
 }
 
-template<class ELEM>
-typename SpecificElementVisitor<ELEM>::iterator_t SpecificElementVisitor<ELEM>::end(){
+template <class ELEM>
+typename SpecificElementVisitor<ELEM>::iterator_t SpecificElementVisitor<ELEM>::end() {
     return allElementsOfTypeE.end();
 }
 
-template<class ELEM>
-typename SpecificElementVisitor<ELEM>::const_iterator_t SpecificElementVisitor<ELEM>::end() const{
+template <class ELEM>
+typename SpecificElementVisitor<ELEM>::const_iterator_t SpecificElementVisitor<ELEM>::end() const {
     return allElementsOfTypeE.end();
 }
 
-template<class ELEM>
+template <class ELEM>
 typename SpecificElementVisitor<ELEM>::reference_t SpecificElementVisitor<ELEM>::front() {
     return allElementsOfTypeE.front();
 }
 
-template<class ELEM>
-typename SpecificElementVisitor<ELEM>::const_reference_t SpecificElementVisitor<ELEM>::front() const{
+template <class ELEM>
+typename SpecificElementVisitor<ELEM>::const_reference_t SpecificElementVisitor<ELEM>::front()
+        const {
     return allElementsOfTypeE.front();
 }
 

--- a/src/Algorithms/DefaultVisitor.cpp
+++ b/src/Algorithms/DefaultVisitor.cpp
@@ -25,18 +25,21 @@
 #include "AbsBeamline/ConstantEFieldCavity.h"
 #include "AbsBeamline/Drift.h"
 #include "AbsBeamline/ElementBase.h"
+#include "AbsBeamline/Laser.h"
 #include "AbsBeamline/Marker.h"
 #include "AbsBeamline/Monitor.h"
 #include "AbsBeamline/Multipole.h"
 #include "AbsBeamline/MultipoleT.h"
 #include "AbsBeamline/Probe.h"
+#include "AbsBeamline/RBend.h"
 #include "AbsBeamline/RFCavity.h"
 #include "AbsBeamline/Ring.h"
+#include "AbsBeamline/SBend.h"
 #include "AbsBeamline/ScalingFFAMagnet.h"
 #include "AbsBeamline/Solenoid.h"
 #include "AbsBeamline/TravelingWave.h"
-#include "AbsBeamline/VerticalFFAMagnet.h"
 #include "AbsBeamline/VariableRFCavity.h"
+#include "AbsBeamline/VerticalFFAMagnet.h"
 
 #include "Beamlines/Beamline.h"
 #include "Beamlines/FlaggedElmPtr.h"
@@ -53,65 +56,43 @@ void DefaultVisitor::execute() {
     itsLine.accept(*this);
 }
 
-void DefaultVisitor::visitComponent(const Component& comp) {
-    applyDefault(comp);
-}
+void DefaultVisitor::visitComponent(const Component& comp) { applyDefault(comp); }
 
 void DefaultVisitor::visitConstantEFieldCavity(const ConstantEFieldCavity& cav) {
     applyDefault(cav);
 }
 
-void DefaultVisitor::visitDrift(const Drift& drf) {
-    applyDefault(drf);
-}
+void DefaultVisitor::visitDrift(const Drift& drf) { applyDefault(drf); }
 
-void DefaultVisitor::visitMarker(const Marker& mark) {
-    applyDefault(mark);
-}
+void DefaultVisitor::visitLaser(const Laser& laser) { applyDefault(laser); }
 
-void DefaultVisitor::visitMonitor(const Monitor& mon) {
-    applyDefault(mon);
-}
+void DefaultVisitor::visitMarker(const Marker& mark) { applyDefault(mark); }
 
-void DefaultVisitor::visitMultipole(const Multipole& mult) {
-    applyDefault(mult);
-}
+void DefaultVisitor::visitMonitor(const Monitor& mon) { applyDefault(mon); }
 
-void DefaultVisitor::visitMultipoleT(const MultipoleT& multT) {
-    applyDefault(multT);
-}
+void DefaultVisitor::visitMultipole(const Multipole& mult) { applyDefault(mult); }
 
-void DefaultVisitor::visitRing(const Ring& ring) {
-    applyDefault(ring);
-}
+void DefaultVisitor::visitMultipoleT(const MultipoleT& multT) { applyDefault(multT); }
 
-void DefaultVisitor::visitRFCavity(const RFCavity& cav) {
-    applyDefault(cav);
-}
+void DefaultVisitor::visitRBend(const RBend& bend) { applyDefault(bend); }
 
-void DefaultVisitor::visitSolenoid(const Solenoid& so) {
-    applyDefault(so);
-}
+void DefaultVisitor::visitRing(const Ring& ring) { applyDefault(ring); }
 
-void DefaultVisitor::visitTravelingWave(const TravelingWave& trw) {
-    applyDefault(trw);
-}
+void DefaultVisitor::visitRFCavity(const RFCavity& cav) { applyDefault(cav); }
 
-void DefaultVisitor::visitScalingFFAMagnet(const ScalingFFAMagnet& spiral) {
-    applyDefault(spiral);
-}
+void DefaultVisitor::visitSBend(const SBend& bend) { applyDefault(bend); }
 
-void DefaultVisitor::visitVerticalFFAMagnet(const VerticalFFAMagnet& mag) {
-    applyDefault(mag);
-}
+void DefaultVisitor::visitSolenoid(const Solenoid& so) { applyDefault(so); }
 
-void DefaultVisitor::visitVariableRFCavity(const VariableRFCavity& cavity) {
-    applyDefault(cavity);
-}
+void DefaultVisitor::visitTravelingWave(const TravelingWave& trw) { applyDefault(trw); }
 
-void DefaultVisitor::visitProbe(const Probe& probe) {
-    applyDefault(probe);
-}
+void DefaultVisitor::visitScalingFFAMagnet(const ScalingFFAMagnet& spiral) { applyDefault(spiral); }
+
+void DefaultVisitor::visitVerticalFFAMagnet(const VerticalFFAMagnet& mag) { applyDefault(mag); }
+
+void DefaultVisitor::visitVariableRFCavity(const VariableRFCavity& cavity) { applyDefault(cavity); }
+
+void DefaultVisitor::visitProbe(const Probe& probe) { applyDefault(probe); }
 
 void DefaultVisitor::visitBeamline(const Beamline& bl) {
     // Default behaviour: Apply algorithm to all beamline members.
@@ -129,5 +110,4 @@ void DefaultVisitor::visitFlaggedElmPtr(const FlaggedElmPtr& fep) {
     }
 }
 
-void DefaultVisitor::applyDefault(const ElementBase&) {
-}
+void DefaultVisitor::applyDefault(const ElementBase&) {}

--- a/src/Algorithms/DefaultVisitor.h
+++ b/src/Algorithms/DefaultVisitor.h
@@ -54,6 +54,9 @@ public:
     /// Apply the algorithm to a drift space.
     void visitDrift(const Drift&) override;
 
+    /// Apply the algorithm to a laser.
+    void visitLaser(const Laser&) override;
+
     /// Apply the algorithm to a FlaggedElmPtr.
     void visitFlaggedElmPtr(const FlaggedElmPtr&) override;
 
@@ -69,8 +72,14 @@ public:
     /// Apply the algorithm to an arbitrary multipole.
     void visitMultipoleT(const MultipoleT&) override;
 
+    /// Apply the algorithm to a rectangular bend.
+    void visitRBend(const RBend&) override;
+
     /// Apply the algorithm to a Ring.
     void visitRing(const Ring&) override;
+
+    /// Apply the algorithm to a sector bend.
+    void visitSBend(const SBend&) override;
 
     /// Apply the algorithm to a RF cavity.
     void visitRFCavity(const RFCavity&) override;
@@ -109,7 +118,7 @@ protected:
 
 private:
     // Not implemented.
-    DefaultVisitor() = delete;
+    DefaultVisitor()                      = delete;
     DefaultVisitor(const DefaultVisitor&) = delete;
     void operator=(const DefaultVisitor&) = delete;
 

--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -115,19 +115,12 @@ ParallelTracker::~ParallelTracker() {}
 /**
  * @copybrief ParallelTracker::visitComponent
  */
-void ParallelTracker::visitComponent(const Component& comp) {
-    if (comp.getType() == ElementType::LASER) {
-        throw LogicalError(
-                "ParallelTracker::visitComponent()",
-                "Tracking of the \"LASER\" element is not implemented yet.");
-    }
+void ParallelTracker::visitComponent(const Component& comp) { Tracker::visitComponent(comp); }
 
-    if (comp.getType() == ElementType::SBEND || comp.getType() == ElementType::RBEND) {
-        itsOpalBeamline_m.visit(comp, *this, *itsBunch_m);
-        return;
-    }
-
-    Tracker::visitComponent(comp);
+void ParallelTracker::visitLaser(const Laser&) {
+    throw LogicalError(
+            "ParallelTracker::visitLaser()",
+            "Tracking of the \"LASER\" element is not implemented yet.");
 }
 
 /**

--- a/src/Algorithms/ParallelTracker.h
+++ b/src/Algorithms/ParallelTracker.h
@@ -2,7 +2,8 @@
  * @file ParallelTracker.h
  * @brief Visitor-based parallel tracker with time as the independent variable.
  *
- * @copyright Copyright (c) 200x - 2014, Christof Kraus, Paul Scherrer Institut, Villigen PSI, Switzerland
+ * @copyright Copyright (c) 200x - 2014, Christof Kraus, Paul Scherrer Institut, Villigen PSI,
+ * Switzerland
  * @copyright 2015 - 2016, Christof Metzger-Kraus, Helmholtz-Zentrum Berlin, Germany
  * @copyright 2017 - 2020, Christof Metzger-Kraus
  * @copyright 2025 - present, Ryan Ammann, Paul Scherrer Institut, Villigen PSI, Switzerland
@@ -37,10 +38,13 @@
 #include "AbsBeamline/ConstantEFieldCavity.h"
 #include "AbsBeamline/Drift.h"
 #include "AbsBeamline/ElementBase.h"
+#include "AbsBeamline/Laser.h"
 #include "AbsBeamline/Marker.h"
 #include "AbsBeamline/Multipole.h"
 #include "AbsBeamline/MultipoleT.h"
+#include "AbsBeamline/RBend.h"
 #include "AbsBeamline/RFCavity.h"
+#include "AbsBeamline/SBend.h"
 #include "AbsBeamline/ScalingFFAMagnet.h"
 #include "AbsBeamline/Solenoid.h"
 #include "AbsBeamline/TravelingWave.h"
@@ -64,18 +68,18 @@ class PluginElement;
  */
 class ParallelTracker : public Tracker {
 private:
-
-    DataSink* itsDataSink_m;                ///< Borrowed beam statistics and phase-space output sink.
-    OpalBeamline itsOpalBeamline_m;          ///< Cloned field elements and coordinate transforms.
-    bool globalEOL_m;                       ///< End-of-line flag (e.g. orbit threader out of bounds).
-    double zstart_m;                        ///< Path-length start position for the track (m).
+    DataSink* itsDataSink_m;         ///< Borrowed beam statistics and phase-space output sink.
+    OpalBeamline itsOpalBeamline_m;  ///< Cloned field elements and coordinate transforms.
+    bool globalEOL_m;                ///< End-of-line flag (e.g. orbit threader out of bounds).
+    double zstart_m;                 ///< Path-length start position for the track (m).
 
     /** Step-size segments: z-stop, dt, and steps per segment. */
     StepSizeConfig stepSizes_m;
 
-    double dtCurrentTrack_m;                ///< Global @f$\Delta t@f$ for the current track segment.
-    unsigned long long repartFreq_m;       ///< Space-charge repartition period (steps); off on one rank.
-    std::vector<std::vector<std::shared_ptr<SamplingBase>>> emittingSamplers_m; ///< Per-container emitters.
+    double dtCurrentTrack_m;          ///< Global @f$\Delta t@f$ for the current track segment.
+    unsigned long long repartFreq_m;  ///< Space-charge repartition period (steps); off on one rank.
+    std::vector<std::vector<std::shared_ptr<SamplingBase>>>
+            emittingSamplers_m;  ///< Per-container emitters.
 
     // --- Timers ---
     IpplTimings::TimerRef timeIntegrationTimer1_m;
@@ -107,20 +111,20 @@ public:
      * @param dt                Time step per segment (s).
      * @param emittingSamplers  Optional per-container samplers for emitParticles(t, dt).
      */
-    explicit ParallelTracker(const Beamline& bl, PartBunch_t& bunch,
-        DataSink* ds, bool revBeam,
-        const std::vector<unsigned long long>& maxSTEPS, 
-        double zstart, const std::vector<double>& zstop, 
-        const std::vector<double>& dt,
-        const std::vector<std::vector<std::shared_ptr<SamplingBase>>>& emittingSamplers = {});
+    explicit ParallelTracker(
+            const Beamline& bl, PartBunch_t& bunch, DataSink* ds, bool revBeam,
+            const std::vector<unsigned long long>& maxSTEPS, double zstart,
+            const std::vector<double>& zstop, const std::vector<double>& dt,
+            const std::vector<std::vector<std::shared_ptr<SamplingBase>>>& emittingSamplers = {});
 
     /// @brief Destructor; releases tracker resources.
     virtual ~ParallelTracker();
 
-    /// @brief Visit the full beamline (iterates elements into OpalBeamline). Overrides DefaultVisitor.
+    /// @brief Visit the full beamline (iterates elements into OpalBeamline). Overrides
+    /// DefaultVisitor.
     virtual void visitBeamline(const Beamline&);
 
-    /// @brief Visit a generic component; rejects LASER (not implemented).
+    /// @brief Visit a generic component using the base tracker behavior.
     virtual void visitComponent(const Component&);
 
     /// @brief Apply the algorithm to a constant E-field cavity.
@@ -128,6 +132,9 @@ public:
 
     /// @brief Apply the algorithm to a drift.
     virtual void visitDrift(const Drift&);
+
+    /// @brief Reject laser tracking until dedicated laser tracking is implemented.
+    virtual void visitLaser(const Laser&);
 
     /// @brief Apply the algorithm to a marker.
     virtual void visitMarker(const Marker&);
@@ -138,8 +145,14 @@ public:
     /// @brief Apply the algorithm to a multipole (templated type).
     virtual void visitMultipoleT(const MultipoleT&);
 
+    /// @brief Apply the algorithm to a rectangular bend.
+    virtual void visitRBend(const RBend&);
+
     /// @brief Apply the algorithm to an RF cavity.
     virtual void visitRFCavity(const RFCavity&);
+
+    /// @brief Apply the algorithm to a sector bend.
+    virtual void visitSBend(const SBend&);
 
     /// @brief Apply the algorithm to a traveling wave cavity.
     virtual void visitTravelingWave(const TravelingWave&);
@@ -155,16 +168,14 @@ public:
      * @param pusher Boris pusher instance.
      * @param pc     Non-null particle container.
      */
-    void kickParticles(const BorisPusher& pusher,
-                       PartBunch_t::ParticleContainer_t& pc);
-                       
+    void kickParticles(const BorisPusher& pusher, PartBunch_t::ParticleContainer_t& pc);
+
     /**
      * @brief Boris position push (unitless positions) on one container.
      * @param pusher Boris pusher instance.
      * @param pc     Non-null particle container.
      */
-    void pushParticles(const BorisPusher& pusher,
-                       PartBunch_t::ParticleContainer_t& pc);
+    void pushParticles(const BorisPusher& pusher, PartBunch_t::ParticleContainer_t& pc);
 
     /// @brief First half of the leapfrog step: push all active containers.
     void timeIntegration1(BorisPusher& pusher);
@@ -197,7 +208,6 @@ public:
     void setTime();
 
 private:
-
     /// @brief Update reference trajectories and lab/reference coordinate transforms.
     void updateReference(const BorisPusher& pusher);
 
@@ -300,8 +310,16 @@ inline void ParallelTracker::visitMultipoleT(const MultipoleT& mult) {
     itsOpalBeamline_m.visit(mult, *this, *itsBunch_m);
 }
 
+inline void ParallelTracker::visitRBend(const RBend& bend) {
+    itsOpalBeamline_m.visit(bend, *this, *itsBunch_m);
+}
+
 inline void ParallelTracker::visitRFCavity(const RFCavity& as) {
     itsOpalBeamline_m.visit(as, *this, *itsBunch_m);
+}
+
+inline void ParallelTracker::visitSBend(const SBend& bend) {
+    itsOpalBeamline_m.visit(bend, *this, *itsBunch_m);
 }
 
 inline void ParallelTracker::visitTravelingWave(const TravelingWave& tw) {

--- a/unit_tests/AbsBeamline/TestMultipoleT.cpp
+++ b/unit_tests/AbsBeamline/TestMultipoleT.cpp
@@ -86,13 +86,16 @@ public:
     void visitConstantEFieldCavity(const ConstantEFieldCavity&) override {}
     void visitDrift(const Drift&) override {}
     void visitFlaggedElmPtr(const FlaggedElmPtr&) override {}
+    void visitLaser(const Laser&) override {}
     void visitMarker(const Marker&) override {}
     void visitMonitor(const Monitor&) override {}
     void visitMultipole(const Multipole&) override {}
     void visitMultipoleT(const MultipoleT&) override {}
+    void visitRBend(const RBend&) override {}
     void visitRFCavity(const RFCavity&) override {}
     void visitScalingFFAMagnet(const ScalingFFAMagnet&) override {}
     void visitRing(const Ring&) override {}
+    void visitSBend(const SBend&) override {}
     void visitSolenoid(const Solenoid&) override {}
     void visitTravelingWave(const TravelingWave&) override {}
     void visitVerticalFFAMagnet(const VerticalFFAMagnet&) override {}

--- a/unit_tests/AbsBeamline/TestVariableRFCavity.cpp
+++ b/unit_tests/AbsBeamline/TestVariableRFCavity.cpp
@@ -56,13 +56,16 @@ public:
     void visitConstantEFieldCavity(const ConstantEFieldCavity&) override {}
     void visitDrift(const Drift&) override {}
     void visitFlaggedElmPtr(const FlaggedElmPtr&) override {}
+    void visitLaser(const Laser&) override {}
     void visitMarker(const Marker&) override {}
     void visitMonitor(const Monitor&) override {}
     void visitMultipole(const Multipole&) override {}
     void visitMultipoleT(const MultipoleT&) override {}
+    void visitRBend(const RBend&) override {}
     void visitRFCavity(const RFCavity&) override {}
     void visitScalingFFAMagnet(const ScalingFFAMagnet&) override {}
     void visitRing(const Ring&) override {}
+    void visitSBend(const SBend&) override {}
     void visitSolenoid(const Solenoid&) override {}
     void visitTravelingWave(const TravelingWave&) override {}
     void visitVerticalFFAMagnet(const VerticalFFAMagnet&) override {}

--- a/unit_tests/Structure/TestLaser.cpp
+++ b/unit_tests/Structure/TestLaser.cpp
@@ -1,6 +1,9 @@
+#include "Algorithms/DefaultVisitor.h"
 #include "Algorithms/ParallelTracker.h"
 #include "Attributes/Attributes.h"
 #include "BeamlineCore/LaserRep.h"
+#include "BeamlineCore/RBendRep.h"
+#include "BeamlineCore/SBendRep.h"
 #include "Beamlines/FlaggedElmPtr.h"
 #include "Beamlines/TBeamline.h"
 #include "Elements/OpalLaser.h"
@@ -21,7 +24,23 @@ namespace {
         Attributes::setReal(laser.itsAttr[OpalLaser::WAISTY], 6.0e-6);
         Attributes::setRealArray(laser.itsAttr[OpalLaser::DIR], {0.0, 0.0, -2.0});
     }
-}
+
+    class DispatchRecordingVisitor : public DefaultVisitor {
+    public:
+        explicit DispatchRecordingVisitor(const Beamline& beamline)
+            : DefaultVisitor(beamline, false, false) {}
+
+        void visitComponent(const Component&) override { sawComponent = true; }
+        void visitLaser(const Laser&) override { sawLaser = true; }
+        void visitSBend(const SBend&) override { sawSBend = true; }
+        void visitRBend(const RBend&) override { sawRBend = true; }
+
+        bool sawComponent = false;
+        bool sawLaser     = false;
+        bool sawSBend     = false;
+        bool sawRBend     = false;
+    };
+}  // namespace
 
 TEST(TestLaser, UpdateStoresValidatedParameters) {
     OpalLaser laser;
@@ -159,32 +178,55 @@ TEST(TestLaser, LinearComptonForwardPhotonEnergyMatchesExactNinetyDegreeKinemati
     beamDirection(2) = 1.0;
 
     const double electronTotalEnergyGeV = 1.0;
-    const double laserPhotonEnergyGeV = rep->getPhotonEnergyGeV();
-    const double electronMomentumGeV = std::sqrt(
-        electronTotalEnergyGeV * electronTotalEnergyGeV - Physics::m_e * Physics::m_e);
+    const double laserPhotonEnergyGeV   = rep->getPhotonEnergyGeV();
+    const double electronMomentumGeV    = std::sqrt(
+            electronTotalEnergyGeV * electronTotalEnergyGeV - Physics::m_e * Physics::m_e);
     const double expectedInvariantX =
-        2.0 * laserPhotonEnergyGeV * electronTotalEnergyGeV / (Physics::m_e * Physics::m_e);
+            2.0 * laserPhotonEnergyGeV * electronTotalEnergyGeV / (Physics::m_e * Physics::m_e);
     const double stableEnergyMinusMomentum =
-        Physics::m_e * Physics::m_e / (electronTotalEnergyGeV + electronMomentumGeV);
+            Physics::m_e * Physics::m_e / (electronTotalEnergyGeV + electronMomentumGeV);
     const double expectedForwardPhotonEnergyGeV =
-        laserPhotonEnergyGeV * electronTotalEnergyGeV
-        / (stableEnergyMinusMomentum + laserPhotonEnergyGeV);
+            laserPhotonEnergyGeV * electronTotalEnergyGeV
+            / (stableEnergyMinusMomentum + laserPhotonEnergyGeV);
 
-    EXPECT_NEAR(rep->getLinearComptonInvariantX(electronTotalEnergyGeV, beamDirection),
-                expectedInvariantX,
-                expectedInvariantX * 1.0e-12);
-    EXPECT_NEAR(rep->getLinearComptonForwardPhotonEnergyGeV(electronTotalEnergyGeV, beamDirection),
-                expectedForwardPhotonEnergyGeV,
-                expectedForwardPhotonEnergyGeV * 1.0e-12);
+    EXPECT_NEAR(
+            rep->getLinearComptonInvariantX(electronTotalEnergyGeV, beamDirection),
+            expectedInvariantX, expectedInvariantX * 1.0e-12);
+    EXPECT_NEAR(
+            rep->getLinearComptonForwardPhotonEnergyGeV(electronTotalEnergyGeV, beamDirection),
+            expectedForwardPhotonEnergyGeV, expectedForwardPhotonEnergyGeV * 1.0e-12);
 }
 
-/* TODO: Change to match new ParallelTracker constructor
-TEST(TestLaser, ParallelTrackerRejectsLaserComponent) {
+TEST(TestLaser, BeamlineVisitorDispatchesLaserAndBendsToSpecificHooks) {
     TBeamline<FlaggedElmPtr> beamline("LINE");
-    PartData reference(0.0, 1.0, 1.0);
-    ParallelTracker tracker(beamline, reference, false, false);
-    LaserRep laser("LASER");
 
-    EXPECT_THROW(tracker.visitComponent(laser), LogicalError);
+    {
+        DispatchRecordingVisitor visitor(beamline);
+        LaserRep laser("LASER");
+        laser.accept(visitor);
+        EXPECT_TRUE(visitor.sawLaser);
+        EXPECT_FALSE(visitor.sawSBend);
+        EXPECT_FALSE(visitor.sawRBend);
+        EXPECT_FALSE(visitor.sawComponent);
+    }
+
+    {
+        DispatchRecordingVisitor visitor(beamline);
+        SBendRep sbend("SBEND");
+        sbend.accept(visitor);
+        EXPECT_FALSE(visitor.sawLaser);
+        EXPECT_TRUE(visitor.sawSBend);
+        EXPECT_FALSE(visitor.sawRBend);
+        EXPECT_FALSE(visitor.sawComponent);
+    }
+
+    {
+        DispatchRecordingVisitor visitor(beamline);
+        RBendRep rbend("RBEND");
+        rbend.accept(visitor);
+        EXPECT_FALSE(visitor.sawLaser);
+        EXPECT_FALSE(visitor.sawSBend);
+        EXPECT_TRUE(visitor.sawRBend);
+        EXPECT_FALSE(visitor.sawComponent);
+    }
 }
-*/


### PR DESCRIPTION
  - src/AbsBeamline/BeamlineVisitor.h - added visitLaser(const Laser&), visitSBend(const SBend&), visitRBend(const RBend&) - src/AbsBeamline/Laser.cpp, src/AbsBeamline/SBend.cpp, src/AbsBeamline/RBend.cpp - accept() now dispatches to the specific visitor hook instead of visitComponent() - src/Algorithms/DefaultVisitor.h, src/Algorithms/DefaultVisitor.cpp - added default applyDefault(...) forwarding for the three new hooks - src/AbsBeamline/SpecificElementVisitor.h - added visitLaser(...) support; existing visitSBend/RBend(...) now line up with the interface - src/Algorithms/ParallelTracker.cpp, src/Algorithms/ParallelTracker.h - removed the Laser/SBEND/RBEND type catch from visitComponent() - added dedicated visitLaser, visitSBend, visitRBend handling - visitLaser() still throws the same “not implemented yet” error, but now through the typed hook - unit_tests/Structure/TestLaser.cpp - added a visitor-dispatch regression proving Laser, SBEND, and RBEND hit their specific hooks - unit_tests/AbsBeamline/TestMultipoleT.cpp, unit_tests/AbsBeamline/TestVariableRFCavity.cpp - updated direct BeamlineVisitor test doubles to satisfy the new interface

  Verification:

  - cmake -S . -B build -DOPALX_ENABLE_UNIT_TESTS=ON
    - cmake --build build --target TestLaser TestMultipoleT TestVariableRFCavity -j4
      - ctest --test-dir /Users/adelmann/git/opalx/build --output-on-failure -R '^(TestLaser|TestMultipoleT|TestVariableRFCavity)$'