### PR TITLE
Add BEAMS

### DIFF
--- a/src/Track/TrackCmd.cpp
+++ b/src/Track/TrackCmd.cpp
@@ -213,7 +213,8 @@ void TrackCmd::execute() {
         beams.push_back(Beam::find(name));  // fail fast
     }
 
-    // Current tracker supports only a single beam; use the first one for now.
+    // The first beam supplies the reference particle; TrackRun resolves and
+    // tracks the full selected beam list.
     Beam* beam = beams.front();
 
     // std::cout << "TrackCmd::execute" << std::endl;


### PR DESCRIPTION
Clarify TRACK BEAMS reference beam handling

Updates the TrackCmd comment to reflect the current multi-beam flow: the first selected beam provides the reference particle, while TrackRun resolves and tracks the full BEAMS list.




