### PR TITLE
Activate particle IDs in OPALX

### DIFF
--- a/src/Distribution/Distribution.cpp
+++ b/src/Distribution/Distribution.cpp
@@ -50,8 +50,6 @@ extern Inform* gmsg;
 
 using GeneratorPool = typename Kokkos::Random_XorShift64_Pool<>;
 
-using Base = ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>>;
-
 using view_type = typename ippl::detail::ViewType<ippl::Vector<double, Dim>, 1>::view_type;
 
 namespace DISTRIBUTION {

--- a/src/Distribution/Distribution.cpp
+++ b/src/Distribution/Distribution.cpp
@@ -31,8 +31,8 @@
 #include "Utilities/Util.h"
 #include "Utility/IpplTimings.h"
 
-#include "Utilities/Random.h"
 #include "Utilities/GSLCompat.h"
+#include "Utilities/Random.h"
 
 #include <filesystem>
 #include <regex>
@@ -102,16 +102,16 @@ namespace {
 
 Distribution::Distribution()
     : Definition(
-        DISTRIBUTION::SIZE, "DISTRIBUTION",
-        "The DISTRIBUTION statement defines data for the 6D particle distribution."),
+              DISTRIBUTION::SIZE, "DISTRIBUTION",
+              "The DISTRIBUTION statement defines data for the 6D particle distribution."),
       totalNumberParticles_m(0),
       distrTypeT_m(DistributionType::NODIST),
       avrgpz_m(0.0) {
-    itsAttr[DISTRIBUTION::TYPE] =
-        Attributes::makePredefinedString("TYPE", "Distribution type.", {"GAUSS", "MULTIVARIATEGAUSS", "FLATTOP", "FROMFILE"});
+    itsAttr[DISTRIBUTION::TYPE] = Attributes::makePredefinedString(
+            "TYPE", "Distribution type.", {"GAUSS", "MULTIVARIATEGAUSS", "FLATTOP", "FROMFILE"});
 
     itsAttr[DISTRIBUTION::FNAME] =
-        Attributes::makeString("FNAME", "File for reading in 6D particle coordinates.", "");
+            Attributes::makeString("FNAME", "File for reading in 6D particle coordinates.", "");
 
     // Parameters for defining an initial distribution.
     itsAttr[DISTRIBUTION::SIGMAX]  = Attributes::makeReal("SIGMAX", "SIGMAx (m)", 0.0);
@@ -123,56 +123,71 @@ Distribution::Distribution()
 
     itsAttr[DISTRIBUTION::CORR] = Attributes::makeRealArray("CORR", "r correlation");
 
-    itsAttr[DISTRIBUTION::CUTOFFPX] = Attributes::makeReal("CUTOFFPX", "Distribution cutoff px dimension in units of sigma.", 3.0);
-    itsAttr[DISTRIBUTION::CUTOFFPY] = Attributes::makeReal("CUTOFFPY", "Distribution cutoff py dimension in units of sigma.", 3.0);
-    itsAttr[DISTRIBUTION::CUTOFFPZ] = Attributes::makeReal("CUTOFFPZ", "Distribution cutoff pz dimension in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFPX] = Attributes::makeReal(
+            "CUTOFFPX", "Distribution cutoff px dimension in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFPY] = Attributes::makeReal(
+            "CUTOFFPY", "Distribution cutoff py dimension in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFPZ] = Attributes::makeReal(
+            "CUTOFFPZ", "Distribution cutoff pz dimension in units of sigma.", 3.0);
 
-    itsAttr[DISTRIBUTION::CUTOFFX] = Attributes::makeReal("CUTOFFX", "Distribution cutoff x direction in units of sigma.", 3.0);
-    itsAttr[DISTRIBUTION::CUTOFFY] = Attributes::makeReal("CUTOFFY", "Distribution cutoff r direction in units of sigma.", 3.0);
-    itsAttr[DISTRIBUTION::CUTOFFLONG] = Attributes::makeReal("CUTOFFLONG", "Distribution cutoff z or t direction in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFX] = Attributes::makeReal(
+            "CUTOFFX", "Distribution cutoff x direction in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFY] = Attributes::makeReal(
+            "CUTOFFY", "Distribution cutoff r direction in units of sigma.", 3.0);
+    itsAttr[DISTRIBUTION::CUTOFFLONG] = Attributes::makeReal(
+            "CUTOFFLONG", "Distribution cutoff z or t direction in units of sigma.", 3.0);
 
-    itsAttr[DISTRIBUTION::CORRX] = Attributes::makeReal("CORRX", "x/px correlation, (R12 in transport notation).", 0.0);
-    itsAttr[DISTRIBUTION::CORRY] = Attributes::makeReal("CORRY", "y/py correlation, (R34 in transport notation).", 0.0);
-    itsAttr[DISTRIBUTION::CORRZ] = Attributes::makeReal("CORRZ", "z/pz correlation, (R56 in transport notation).", 0.0);
-    itsAttr[DISTRIBUTION::CORRT] = Attributes::makeReal("CORRT", "t/pt correlation, (R56 in transport notation).", 0.0);
+    itsAttr[DISTRIBUTION::CORRX] =
+            Attributes::makeReal("CORRX", "x/px correlation, (R12 in transport notation).", 0.0);
+    itsAttr[DISTRIBUTION::CORRY] =
+            Attributes::makeReal("CORRY", "y/py correlation, (R34 in transport notation).", 0.0);
+    itsAttr[DISTRIBUTION::CORRZ] =
+            Attributes::makeReal("CORRZ", "z/pz correlation, (R56 in transport notation).", 0.0);
+    itsAttr[DISTRIBUTION::CORRT] =
+            Attributes::makeReal("CORRT", "t/pt correlation, (R56 in transport notation).", 0.0);
 
     itsAttr[DISTRIBUTION::SIGMAT] = Attributes::makeReal("SIGMAT", "SIGMAt (m)", 0.0);
-    itsAttr[DISTRIBUTION::TPULSEFWHM] = Attributes::makeReal("TPULSEFWHM", "Pulse FWHM for emitted distribution.", 0.0);
-    itsAttr[DISTRIBUTION::TRISE] = Attributes::makeReal("TRISE", "Rise time for emitted distribution.", 0.0);
-    itsAttr[DISTRIBUTION::TFALL] = Attributes::makeReal("TFALL", "Fall time for emitted distribution.", 0.0);
+    itsAttr[DISTRIBUTION::TPULSEFWHM] =
+            Attributes::makeReal("TPULSEFWHM", "Pulse FWHM for emitted distribution.", 0.0);
+    itsAttr[DISTRIBUTION::TRISE] =
+            Attributes::makeReal("TRISE", "Rise time for emitted distribution.", 0.0);
+    itsAttr[DISTRIBUTION::TFALL] =
+            Attributes::makeReal("TFALL", "Fall time for emitted distribution.", 0.0);
 
-    itsAttr[DISTRIBUTION::FTOSCAMPLITUDE]
-        = Attributes::makeReal("FTOSCAMPLITUDE", "Amplitude of oscillations superimposed "
-                               "on flat top portion of emitted GAUSS "
-                               "distribtuion (in percent of flat top "
-                               "amplitude)",0.0);
+    itsAttr[DISTRIBUTION::FTOSCAMPLITUDE] = Attributes::makeReal(
+            "FTOSCAMPLITUDE",
+            "Amplitude of oscillations superimposed "
+            "on flat top portion of emitted GAUSS "
+            "distribtuion (in percent of flat top "
+            "amplitude)",
+            0.0);
 
-    itsAttr[DISTRIBUTION::FTOSCPERIODS]
-        = Attributes::makeReal("FTOSCPERIODS", "Number of oscillations superimposed on "
-                               "flat top portion of emitted GAUSS "
-                               "distribution", 0.0);
+    itsAttr[DISTRIBUTION::FTOSCPERIODS] = Attributes::makeReal(
+            "FTOSCPERIODS",
+            "Number of oscillations superimposed on "
+            "flat top portion of emitted GAUSS "
+            "distribution",
+            0.0);
 
-    itsAttr[DISTRIBUTION::EMITTED] =
-        Attributes::makeBool("EMITTED",
-                             "Emitted beam, from cathode, as opposed to "
-                             "an injected beam.",
-                             false);
+    itsAttr[DISTRIBUTION::EMITTED] = Attributes::makeBool(
+            "EMITTED",
+            "Emitted beam, from cathode, as opposed to "
+            "an injected beam.",
+            false);
 
     itsAttr[DISTRIBUTION::NPARTDIST] = Attributes::makeReal(
-        "NPARTDIST",
-        "Number of macroparticles for this DISTRIBUTION. "
-        "If 0 or negative, this distribution does not specify its own count.",
-        0.0);
+            "NPARTDIST",
+            "Number of macroparticles for this DISTRIBUTION. "
+            "If 0 or negative, this distribution does not specify its own count.",
+            0.0);
 
     registerOwnership(AttributeHandler::STATEMENT);
 }
 
 Distribution::Distribution(const std::string& name, Distribution* parent)
-    : Definition(name, parent) {
-}
+    : Definition(name, parent) {}
 
-Distribution::~Distribution() {
-}
+Distribution::~Distribution() {}
 
 /**
  * Calculate the local number of particles evenly and adjust node 0
@@ -188,20 +203,15 @@ size_t Distribution::getNumOfLocalParticlesToCreate(size_t n) {
     // make sure the total number is exact
     size_t remainder = n % ippl::Comm->size();
     size_t myNode    = ippl::Comm->rank();
-    if (myNode < remainder)
-        ++locNumber;
+    if (myNode < remainder) ++locNumber;
 
     return locNumber;
 }
 
 /// Distribution can only be replaced by another distribution.
-bool Distribution::canReplaceBy(Object* object) {
-    return dynamic_cast<Distribution*>(object) != 0;
-}
+bool Distribution::canReplaceBy(Object* object) { return dynamic_cast<Distribution*>(object) != 0; }
 
-Distribution* Distribution::clone(const std::string& name) {
-    return new Distribution(name, this);
-}
+Distribution* Distribution::clone(const std::string& name) { return new Distribution(name, this); }
 
 void Distribution::execute() {
     setAttributes();
@@ -241,7 +251,7 @@ Inform& Distribution::printInfo(Inform& os) const {
                 break;
             default:
                 throw OpalException("Distribution Param", "Unknown \"TYPE\" of \"DISTRIBUTION\"");
-         }
+        }
         os << "* " << endl;
         os << "* Distribution is injected." << endl;
     }
@@ -252,17 +262,11 @@ Inform& Distribution::printInfo(Inform& os) const {
     return os;
 }
 
-void Distribution::setAvrgPz(double avrgpz){
-    avrgpz_m = avrgpz;
-}
+void Distribution::setAvrgPz(double avrgpz) { avrgpz_m = avrgpz; }
 
-void Distribution::setTEmission(double tEmission) {
-        tEmission_m = tEmission;
-}
+void Distribution::setTEmission(double tEmission) { tEmission_m = tEmission; }
 
-double Distribution::getTEmission() const {
-        return tEmission_m;
-}
+double Distribution::getTEmission() const { return tEmission_m; }
 
 void Distribution::setDistParametersGauss() {
     /*
@@ -284,10 +288,10 @@ void Distribution::setDistParametersGauss() {
                          Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFLONG]));
     */
 
-    //if (std::abs(Attributes::getReal(itsAttr[Attrib::Distribution::SIGMAR])) > 0.0) {
-    //    cutoffR_m[0] = Attributes::getReal(itsAttr[Attrib::Distribution::CUTOFFR]);
-    //    cutoffR_m[1] = Attributes::getReal(itsAttr[Attrib::Distribution::CUTOFFR]);
-    //}
+    // if (std::abs(Attributes::getReal(itsAttr[Attrib::Distribution::SIGMAR])) > 0.0) {
+    //     cutoffR_m[0] = Attributes::getReal(itsAttr[Attrib::Distribution::CUTOFFR]);
+    //     cutoffR_m[1] = Attributes::getReal(itsAttr[Attrib::Distribution::CUTOFFR]);
+    // }
 
     setSigmaR_m();
     setSigmaP_m();
@@ -296,17 +300,16 @@ void Distribution::setDistParametersGauss() {
 }
 
 void Distribution::setDistParametersMultiVariateGauss() {
-
     cutoffR_m = 3.;
     cutoffP_m = 3.;
 
     // initialize the covariance matrix to identity
-    for (unsigned int i = 0; i < 6; ++ i) {
-        for (unsigned int j = 0; j < 6; ++ j) {
-            if (i==j)
-               correlationMatrix_m[i][j] = 1.0;
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            if (i == j)
+                correlationMatrix_m[i][j] = 1.0;
             else
-               correlationMatrix_m[i][j] = 0.0;
+                correlationMatrix_m[i][j] = 0.0;
         }
     }
 
@@ -314,29 +317,29 @@ void Distribution::setDistParametersMultiVariateGauss() {
     setSigmaR_m();
     setSigmaP_m();
 
-    for (unsigned int i = 0; i < 3; ++ i){
-        correlationMatrix_m[2*i  ][2*i  ] = sigmaR_m[i]*sigmaR_m[i];
-        correlationMatrix_m[2*i+1][2*i+1] = sigmaP_m[i]*sigmaP_m[i];
+    for (unsigned int i = 0; i < 3; ++i) {
+        correlationMatrix_m[2 * i][2 * i]         = sigmaR_m[i] * sigmaR_m[i];
+        correlationMatrix_m[2 * i + 1][2 * i + 1] = sigmaP_m[i] * sigmaP_m[i];
     }
 
     std::vector<double> cr = Attributes::getRealArray(itsAttr[DISTRIBUTION::CORR]);
 
     if (!cr.empty()) {
-            // read off-diagonal correlation matrix from input file
-            if (cr.size() == 15) {
-                *gmsg << "* Use r to specify correlations" << endl;
-                unsigned int k = 0;
-                for (unsigned int i = 0; i < 5; ++ i) {
-                    for (unsigned int j = i + 1; j < 6; ++ j, ++ k) {
-                        correlationMatrix_m[j][i] = cr.at(k)*cr.at(k);
-                        correlationMatrix_m[i][j] = correlationMatrix_m[j][i]; // impose symmetry
-                    }
+        // read off-diagonal correlation matrix from input file
+        if (cr.size() == 15) {
+            *gmsg << "* Use r to specify correlations" << endl;
+            unsigned int k = 0;
+            for (unsigned int i = 0; i < 5; ++i) {
+                for (unsigned int j = i + 1; j < 6; ++j, ++k) {
+                    correlationMatrix_m[j][i] = cr.at(k) * cr.at(k);
+                    correlationMatrix_m[i][j] = correlationMatrix_m[j][i];  // impose symmetry
                 }
             }
-            else {
-                throw OpalException("Distribution::SetDistParametersGauss",
-                                    "Inconsistent set of correlations specified, check manual");
-            }
+        } else {
+            throw OpalException(
+                    "Distribution::SetDistParametersGauss",
+                    "Inconsistent set of correlations specified, check manual");
+        }
     }
 
     avrgpz_m = 0.0;
@@ -354,19 +357,19 @@ void Distribution::setDistParametersFlatTop() {
     setSigmaP_m();
 
     // initialize the covariance matrix to identity
-    for (unsigned int i = 0; i < 6; ++ i) {
-        for (unsigned int j = 0; j < 6; ++ j) {
-            if (i==j)
-               correlationMatrix_m[i][j] = 1.0;
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            if (i == j)
+                correlationMatrix_m[i][j] = 1.0;
             else
-               correlationMatrix_m[i][j] = 0.0;
+                correlationMatrix_m[i][j] = 0.0;
         }
     }
 
     cutoffR_m = ippl::Vector<double, 3>(
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFX])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFY])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFLONG])));
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFX])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFY])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::CUTOFFLONG])));
 
     correlationMatrix_m[1][0] = Attributes::getReal(itsAttr[DISTRIBUTION::CORRX]);
     correlationMatrix_m[3][2] = Attributes::getReal(itsAttr[DISTRIBUTION::CORRY]);
@@ -380,33 +383,32 @@ void Distribution::setDistParametersFlatTop() {
     if (emitting_m) {
         sigmaR_m[2] = 0.0;
 
-        sigmaTRise_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAT]));
-        sigmaTFall_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAT]));
+        sigmaTRise_m       = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAT]));
+        sigmaTFall_m       = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAT]));
         tPulseLengthFWHM_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TPULSEFWHM]));
 
         FTOSCAmplitude_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCAMPLITUDE]));
-        FTOSCPeriods_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCPERIODS]));
+        FTOSCPeriods_m   = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCPERIODS]));
 
         // If TRISE and TFALL are defined > 0.0 then these attributes
         // override SIGMAT.
         //
         if (std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TRISE])) > 0.0
             || std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TFALL])) > 0.0) {
-
-            double timeRatio = std::sqrt(2.0 * std::log(10.0)) - std::sqrt(2.0 * std::log(10.0 / 9.0));
+            double timeRatio =
+                    std::sqrt(2.0 * std::log(10.0)) - std::sqrt(2.0 * std::log(10.0 / 9.0));
 
             if (std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TRISE])) > 0.0)
-                sigmaTRise_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TRISE]))
-                    / timeRatio;
+                sigmaTRise_m =
+                        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TRISE])) / timeRatio;
 
             if (std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TFALL])) > 0.0)
-                sigmaTFall_m = std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TFALL]))
-                    / timeRatio;
+                sigmaTFall_m =
+                        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::TFALL])) / timeRatio;
         }
 
         // For an emitted beam, the longitudinal cutoff >= 0.
         cutoffR_m[2] = std::abs(cutoffR_m[2]);
-
     }
 }
 
@@ -421,7 +423,7 @@ void Distribution::printDistGauss(Inform& os) const {
     os << "* SIGMAPZ    = " << sigmaP_m[2] << " [Beta Gamma]" << endl;
 }
 
-void Distribution::printDistMultiVariateGauss(Inform& os)  const {
+void Distribution::printDistMultiVariateGauss(Inform& os) const {
     os << "* Distribution type: MULTIVARIATEGAUSS" << endl;
     os << "* " << endl;
     os << "* SIGMAX     = " << sigmaR_m[0] << " [m]" << endl;
@@ -432,37 +434,33 @@ void Distribution::printDistMultiVariateGauss(Inform& os)  const {
     os << "* SIGMAPZ    = " << sigmaP_m[2] << " [Beta Gamma]" << endl;
 
     os << "* input cov matrix = ";
-    for (unsigned int i = 0; i < 6; ++ i) {
-        for (unsigned int j = 0; j < 6; ++ j) {
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
             os << correlationMatrix_m[i][j] << " ";
         }
         os << endl << "                     ";
     }
 }
 
-void Distribution::printDistFlatTop(Inform& os)  const {
+void Distribution::printDistFlatTop(Inform& os) const {
     os << "* Distribution type: FLATTOP" << endl;
     os << "* " << endl;
     os << "* SIGMAX     = " << sigmaR_m[0] << " [m]" << endl;
     os << "* SIGMAY     = " << sigmaR_m[1] << " [m]" << endl;
 
     if (emitting_m) {
-            os << "* Sigma Time Rise               = " << sigmaTRise_m
-               << " [sec]" << endl;
-            os << "* TPULSEFWHM                    = " << tPulseLengthFWHM_m
-               << " [sec]" << endl;
-            os << "* Sigma Time Fall               = " << sigmaTFall_m
-               << " [sec]" << endl;
-            os << "* Longitudinal cutoff           = " << cutoffR_m[2]
-               << " [units of Sigma Time]" << endl;
-            //os << "* Flat top modulation amplitude = "
-            //   << Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCAMPLITUDE])
-            //   << " [Percent of distribution amplitude]" << endl;
-            //os << "* Flat top modulation periods   = "
-            //   << std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCPERIODS]))
-            //   << endl;
-    }
-    else{
+        os << "* Sigma Time Rise               = " << sigmaTRise_m << " [sec]" << endl;
+        os << "* TPULSEFWHM                    = " << tPulseLengthFWHM_m << " [sec]" << endl;
+        os << "* Sigma Time Fall               = " << sigmaTFall_m << " [sec]" << endl;
+        os << "* Longitudinal cutoff           = " << cutoffR_m[2] << " [units of Sigma Time]"
+           << endl;
+        // os << "* Flat top modulation amplitude = "
+        //    << Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCAMPLITUDE])
+        //    << " [Percent of distribution amplitude]" << endl;
+        // os << "* Flat top modulation periods   = "
+        //    << std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::FTOSCPERIODS]))
+        //    << endl;
+    } else {
         os << "* SIGMAZ                        = " << sigmaR_m[2] << " [m]" << endl;
     }
 }
@@ -489,9 +487,8 @@ void Distribution::setAttributes() {
     // Cache per-distribution particle count, if provided.
     // A value <= 0 means \"unspecified\" and will be handled by TrackRun/BEAM.
     const double npartDist = Attributes::getReal(itsAttr[DISTRIBUTION::NPARTDIST]);
-    totalNumberParticles_m = npartDist > 0.0
-                                 ? static_cast<size_t>(npartDist)
-                                 : static_cast<size_t>(0);
+    totalNumberParticles_m =
+            npartDist > 0.0 ? static_cast<size_t>(npartDist) : static_cast<size_t>(0);
 }
 
 void Distribution::setDist() {
@@ -519,19 +516,18 @@ void Distribution::setDist() {
 
 void Distribution::setDistType() {
     static const std::map<std::string, DistributionType> typeStringToDistType_s = {
-        {"NODIST", DistributionType::NODIST},
-        {"GAUSS", DistributionType::GAUSS},
-        {"MULTIVARIATEGAUSS", DistributionType::MULTIVARIATEGAUSS},
-        {"FLATTOP", DistributionType::FLATTOP},
-        {"FROMFILE", DistributionType::FROMFILE}
-    };
+            {"NODIST", DistributionType::NODIST},
+            {"GAUSS", DistributionType::GAUSS},
+            {"MULTIVARIATEGAUSS", DistributionType::MULTIVARIATEGAUSS},
+            {"FLATTOP", DistributionType::FLATTOP},
+            {"FROMFILE", DistributionType::FROMFILE}};
 
     distT_m = Attributes::getString(itsAttr[DISTRIBUTION::TYPE]);
 
     if (distT_m.empty()) {
         throw OpalException(
-            "Distribution::setDistType",
-            "The attribute \"TYPE\" isn't set for the \"DISTRIBUTION\"!");
+                "Distribution::setDistType",
+                "The attribute \"TYPE\" isn't set for the \"DISTRIBUTION\"!");
     } else {
         distrTypeT_m = typeStringToDistType_s.at(distT_m);
     }
@@ -539,15 +535,14 @@ void Distribution::setDistType() {
 
 void Distribution::setSigmaR_m() {
     sigmaR_m = ippl::Vector<double, 3>(
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAX])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAY])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAZ])));
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAX])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAY])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAZ])));
 }
 
 void Distribution::setSigmaP_m() {
     sigmaP_m = ippl::Vector<double, 3>(
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPX])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPY])),
-        std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPZ])));
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPX])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPY])),
+            std::abs(Attributes::getReal(itsAttr[DISTRIBUTION::SIGMAPZ])));
 }
-

--- a/src/PartBunch/ImageChargeScatterController.h
+++ b/src/PartBunch/ImageChargeScatterController.h
@@ -25,7 +25,8 @@ class ImageChargeScatterController {
 public:
     using ParticleCtr_t  = ParticleContainer<T, Dim>;
     using PositionAttr_t = typename ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim>>::particle_position_type;
+            ippl::ParticleSpatialLayout<T, Dim>,
+            Kokkos::DefaultExecutionSpace::memory_space>::particle_position_type;
     using RhoField_t  = Field_t<Dim>;
     using BinPolicy_t = Kokkos::RangePolicy<>;
     using Hash_t      = typename ParticleBinning::AdaptBinsBase<ParticleCtr_t>::hash_type;

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -10,7 +10,7 @@ using ORB = ippl::OrthogonalRecursiveBisection<Field<double, Dim>, T>;
 
 template <typename T, unsigned Dim>
 class LoadBalancer {
-    using Base          = ippl::ParticleBase<
+    using Base = ippl::ParticleBase<
             ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
     using FieldSolver_t = ippl::FieldSolverBase<T, Dim>;
 
@@ -26,64 +26,38 @@ private:
 
 public:
     LoadBalancer(
-        double lbs, std::shared_ptr<FieldContainer<T, Dim>>& fc,
-        std::shared_ptr<ParticleContainer<T, Dim>>& pc, std::shared_ptr<FieldSolver_t>& fs)
+            double lbs, std::shared_ptr<FieldContainer<T, Dim>>& fc,
+            std::shared_ptr<ParticleContainer<T, Dim>>& pc, std::shared_ptr<FieldSolver_t>& fs)
         : loadbalancethreshold_m(lbs),
           rho_m(&fc->getRho()),
           E_m(&fc->getE()),
           phi_m(&fc->getPhi()),
           pc_m(pc),
-          fs_m(fs) {
-    }
+          fs_m(fs) {}
 
-    ~LoadBalancer() {
-    }
+    ~LoadBalancer() {}
 
-    double getLoadBalanceThreshold() const {
-        return loadbalancethreshold_m;
-    }
-    void setLoadBalanceThreshold(double threshold) {
-        loadbalancethreshold_m = threshold;
-    }
+    double getLoadBalanceThreshold() const { return loadbalancethreshold_m; }
+    void setLoadBalanceThreshold(double threshold) { loadbalancethreshold_m = threshold; }
 
-    Field_t<Dim>* getRho() const {
-        return rho_m;
-    }
-    void setRho(Field_t<Dim>* rho) {
-        rho_m = rho;
-    }
+    Field_t<Dim>* getRho() const { return rho_m; }
+    void setRho(Field_t<Dim>* rho) { rho_m = rho; }
 
-    VField_t<T, Dim>* getE() const {
-        return E_m;
-    }
-    void setE(VField_t<T, Dim>* E) {
-        E_m = E;
-    }
+    VField_t<T, Dim>* getE() const { return E_m; }
+    void setE(VField_t<T, Dim>* E) { E_m = E; }
 
-    Field<T, Dim>* getPhi() {
-        return phi_m;
-    }
-    void setPhi(Field<T, Dim>* phi) {
-        phi_m = phi;
-    }
+    Field<T, Dim>* getPhi() { return phi_m; }
+    void setPhi(Field<T, Dim>* phi) { phi_m = phi; }
 
-    std::shared_ptr<ParticleContainer<T, Dim>> getParticleContainer() const {
-        return pc_m;
-    }
-    void setParticleContainer(std::shared_ptr<ParticleContainer<T, Dim>> pc) {
-        pc_m = pc;
-    }
+    std::shared_ptr<ParticleContainer<T, Dim>> getParticleContainer() const { return pc_m; }
+    void setParticleContainer(std::shared_ptr<ParticleContainer<T, Dim>> pc) { pc_m = pc; }
 
-    std::shared_ptr<FieldSolver_t> getFieldSolver() const {
-        return fs_m;
-    }
-    void setFieldSolver(std::shared_ptr<FieldSolver_t> fs) {
-        fs_m = fs;
-    }
+    std::shared_ptr<FieldSolver_t> getFieldSolver() const { return fs_m; }
+    void setFieldSolver(std::shared_ptr<FieldSolver_t> fs) { fs_m = fs; }
 
     void updateLayout(
-        ippl::FieldLayout<Dim>* fl, ippl::UniformCartesian<T, Dim>* mesh,
-        bool& isFirstRepartition) {
+            ippl::FieldLayout<Dim>* fl, ippl::UniformCartesian<T, Dim>* mesh,
+            bool& isFirstRepartition) {
         // Update local fields
 
         static IpplTimings::TimerRef tupdateLayout = IpplTimings::getTimer("updateLayout");
@@ -113,35 +87,33 @@ public:
     }
 
     void repartition(
-        ippl::FieldLayout<Dim>* fl, ippl::UniformCartesian<T, Dim>* mesh,
-        bool& isFirstRepartition) {
+            ippl::FieldLayout<Dim>* fl, ippl::UniformCartesian<T, Dim>* mesh,
+            bool& isFirstRepartition) {
         // Repartition the domains
-
 
         using Base = ippl::ParticleBase<
                 ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
-        typename Base::particle_position_type *R;
-        R = &pc_m->R;
+        typename Base::particle_position_type* R;
+        R        = &pc_m->R;
         bool res = orb.binaryRepartition(*R, *fl, isFirstRepartition);
         if (res != true) {
             std::cout << "Could not repartition!" << std::endl;
             return;
         }
-        // Update                                                                                                                                                                                                                                                                                   
+        // Update
         this->updateLayout(fl, mesh, isFirstRepartition);
         if constexpr (Dim == 2 || Dim == 3) {
-                if (fs_m->getStype() == "FFT") {
-                    std::get<FFTSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
-                }
-                if constexpr (Dim == 3) {
-                        if (fs_m->getStype() == "TG") {
-                            std::get<FFTTruncatedGreenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
-                        } else if (fs_m->getStype() == "OPEN") {
-                            std::get<OpenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
-                        }
-                    }
+            if (fs_m->getStype() == "FFT") {
+                std::get<FFTSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
             }
-        
+            if constexpr (Dim == 3) {
+                if (fs_m->getStype() == "TG") {
+                    std::get<FFTTruncatedGreenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
+                } else if (fs_m->getStype() == "OPEN") {
+                    std::get<OpenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
+                }
+            }
+        }
     }
 
     bool balance(size_type totalP) {
@@ -156,7 +128,7 @@ public:
                 local = 1;
             }
             MPI_Allgather(
-                &local, 1, MPI_INT, res.data(), 1, MPI_INT, ippl::Comm->getCommunicator());
+                    &local, 1, MPI_INT, res.data(), 1, MPI_INT, ippl::Comm->getCommunicator());
 
             for (unsigned int i = 0; i < res.size(); i++) {
                 if (res[i] == 1) {

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -10,7 +10,8 @@ using ORB = ippl::OrthogonalRecursiveBisection<Field<double, Dim>, T>;
 
 template <typename T, unsigned Dim>
 class LoadBalancer {
-    using Base          = ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>>;
+    using Base          = ippl::ParticleBase<
+            ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
     using FieldSolver_t = ippl::FieldSolverBase<T, Dim>;
 
 private:
@@ -117,7 +118,8 @@ public:
         // Repartition the domains
 
 
-        using Base = ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>>;
+        using Base = ippl::ParticleBase<
+                ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
         typename Base::particle_position_type *R;
         R = &pc_m->R;
         bool res = orb.binaryRepartition(*R, *fl, isFirstRepartition);

--- a/src/PartBunch/PartBunch.h
+++ b/src/PartBunch/PartBunch.h
@@ -57,7 +57,8 @@ public:
     using FieldContainer_t    = FieldContainer<T, Dim>;
     using BinnedFieldSolver_t = BinnedFieldSolver<T, Dim>;
     using LoadBalancer_t      = LoadBalancer<T, Dim>;
-    using Base                = ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>>;
+    using Base                = ippl::ParticleBase<
+                           ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
 
     using CoordinateSelector_t = typename ParticleBinning::CoordinateSelector<ParticleContainer_t>;
     using GammaSelector_t      = typename ParticleBinning::GammaSelector<ParticleContainer_t>;

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -60,6 +60,17 @@ template <typename T, unsigned Dim = 3>
 class ParticleContainer
     : public ippl::ParticleBase<
               ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space> {
+    /**
+     * @brief Alias for the `ippl::ParticleBase` specialization this container inherits from.
+     *
+     * The second template argument is a parameter pack of Kokkos view properties forwarded to
+     * the optional `ID` attribute's storage. IPPL gates the `ID` attribute on
+     * `sizeof...(IDProperties) > 0`, so passing any property here turns IDs ON; an empty pack
+     * would leave them disabled. We pass `Kokkos::DefaultExecutionSpace::memory_space` so the
+     * ID view lives in the same space as the rest of the bunch (host or device, matching the
+     * build backend). With IDs enabled, IPPL auto-assigns globally unique `std::int64_t` IDs in
+     * `Base::create()`.
+     */
     using Base = ippl::ParticleBase<
             ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
 

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -57,8 +57,11 @@ using size_type = ippl::detail::size_type;
  * They automatically select the correct underlying storage mode.
  */
 template <typename T, unsigned Dim = 3>
-class ParticleContainer : public ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>> {
-    using Base = ippl::ParticleBase<ippl::ParticleSpatialLayout<T, Dim>>;
+class ParticleContainer
+    : public ippl::ParticleBase<
+              ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space> {
+    using Base = ippl::ParticleBase<
+            ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
 
 private:
     /**

--- a/src/Structure/H5PartWrapperForPT.cpp
+++ b/src/Structure/H5PartWrapperForPT.cpp
@@ -33,11 +33,10 @@
 #include <sstream>
 
 H5PartWrapperForPT::H5PartWrapperForPT(const std::string& fileName, h5_int32_t flags)
-    : H5PartWrapper(fileName, flags) {
-}
+    : H5PartWrapper(fileName, flags) {}
 
 H5PartWrapperForPT::H5PartWrapperForPT(
-    const std::string& fileName, int restartStep, std::string sourceFile, h5_int32_t flags)
+        const std::string& fileName, int restartStep, std::string sourceFile, h5_int32_t flags)
     : H5PartWrapper(fileName, restartStep, sourceFile, flags) {
     if (restartStep == -1) {
         restartStep = H5GetNumSteps(file_m) - 1;
@@ -45,8 +44,7 @@ H5PartWrapperForPT::H5PartWrapperForPT(
     }
 }
 
-H5PartWrapperForPT::~H5PartWrapperForPT() {
-}
+H5PartWrapperForPT::~H5PartWrapperForPT() {}
 
 void H5PartWrapperForPT::readHeader() {
     h5_int64_t numFileAttributes = H5GetNumFileAttribs(file_m);
@@ -59,7 +57,8 @@ void H5PartWrapperForPT::readHeader() {
 
     for (h5_int64_t i = 0; i < numFileAttributes; ++i) {
         REPORTONERROR(H5GetFileAttribInfo(
-            file_m, i, attributeName, lengthAttributeName, &attributeType, &numAttributeElements));
+                file_m, i, attributeName, lengthAttributeName, &attributeType,
+                &numAttributeElements));
 
         attributeNames.insert(attributeName);
     }
@@ -82,7 +81,7 @@ void H5PartWrapperForPT::readHeader() {
         h5_int64_t numAutoPhaseCavities = 0;
         if (!H5HasFileAttrib(file_m, "nAutoPhaseCavities")
             || H5ReadFileAttribInt64(file_m, "nAutoPhaseCavities", &numAutoPhaseCavities)
-                   != H5_SUCCESS) {
+                       != H5_SUCCESS) {
             numAutoPhaseCavities = 0;
         } else {
             for (long i = 0; i < numAutoPhaseCavities; ++i) {
@@ -100,7 +99,7 @@ void H5PartWrapperForPT::readHeader() {
 }
 
 void H5PartWrapperForPT::readStep(
-    PartBunch_t* bunch, h5_ssize_t firstParticle, h5_ssize_t lastParticle) {
+        PartBunch_t* bunch, h5_ssize_t firstParticle, h5_ssize_t lastParticle) {
     h5_ssize_t numStepsInSource = H5GetNumSteps(file_m);
     h5_ssize_t readStep         = numStepsInSource - 1;
     REPORTONERROR(H5SetStep(file_m, readStep));
@@ -119,9 +118,9 @@ void H5PartWrapperForPT::readStepHeader(PartBunch_t* bunch) {
     READSTEPATTRIB(Float64, file_m, "SPOS", &spos);
     pc->set_sPos(spos);
 
-    //h5_int64_t ltstep;
-    //READSTEPATTRIB(Int64, file_m, "LocalTrackStep", &ltstep);
-    //bunch->setLocalTrackStep((long long)(ltstep + 1));
+    // h5_int64_t ltstep;
+    // READSTEPATTRIB(Int64, file_m, "LocalTrackStep", &ltstep);
+    // bunch->setLocalTrackStep((long long)(ltstep + 1));
 
     h5_int64_t gtstep;
     READSTEPATTRIB(Int64, file_m, "GlobalTrackStep", &gtstep);
@@ -146,12 +145,12 @@ void H5PartWrapperForPT::readStepHeader(PartBunch_t* bunch) {
 }
 
 void H5PartWrapperForPT::readStepData(
-    PartBunch_t* /*bunch*/, h5_ssize_t firstParticle, h5_ssize_t lastParticle) {
+        PartBunch_t* /*bunch*/, h5_ssize_t firstParticle, h5_ssize_t lastParticle) {
     h5_ssize_t numParticles = getNumParticles();
     if (lastParticle >= numParticles || firstParticle > lastParticle) {
         throw OpalException(
-            "H5PartWrapperForPT::readStepData",
-            "the provided particle numbers don't match the number of particles in the file");
+                "H5PartWrapperForPT::readStepData",
+                "the provided particle numbers don't match the number of particles in the file");
     }
 
     REPORTONERROR(H5PartSetView(file_m, firstParticle, lastParticle));
@@ -205,7 +204,8 @@ void H5PartWrapperForPT::readStepData(
     }
 
     REPORTONERROR(H5PartSetView(file_m, -1, -1));
-    *gmsg << "not implemented:: file: " << __FILE__ << " line: " << __LINE__ << " function: " << __func__ << endl;
+    *gmsg << "not implemented:: file: " << __FILE__ << " line: " << __LINE__
+          << " function: " << __func__ << endl;
 }
 
 void H5PartWrapperForPT::writeHeader() {
@@ -292,12 +292,10 @@ void H5PartWrapperForPT::writeHeader() {
 }
 
 void H5PartWrapperForPT::writeStep(
-    PartBunch_t* bunch, const std::map<std::string, double>& additionalStepAttributes,
-    size_t particleContainerIndex) {
-
+        PartBunch_t* bunch, const std::map<std::string, double>& additionalStepAttributes,
+        size_t particleContainerIndex) {
     auto pc = bunch->getParticleContainer(particleContainerIndex);
-    if (!pc || pc->getTotalNum() == 0)
-        return;
+    if (!pc || pc->getTotalNum() == 0) return;
 
     open(H5_O_APPENDONLY);
     pc->updateMoments();
@@ -307,8 +305,8 @@ void H5PartWrapperForPT::writeStep(
 }
 
 void H5PartWrapperForPT::writeStepHeader(
-    PartBunch_t* bunch, const std::map<std::string, double>& additionalStepAttributes,
-    size_t particleContainerIndex) {
+        PartBunch_t* bunch, const std::map<std::string, double>& additionalStepAttributes,
+        size_t particleContainerIndex) {
     auto pc                      = bunch->getParticleContainer(particleContainerIndex);
     double actPos                = pc->get_sPos();
     double t                     = bunch->getT();
@@ -326,18 +324,18 @@ void H5PartWrapperForPT::writeStepHeader(
     Vector_t<double, 3> RefPartR   = pc->getRefPartR();
     Vector_t<double, 3> RefPartP   = pc->getRefPartP();
     Vector_t<double, 3>
-        TaitBryant;  // ADA = Util::getTaitBryantAngles(bunch->toLabTrafo_m.getRotation());
+            TaitBryant;  // ADA = Util::getTaitBryantAngles(bunch->toLabTrafo_m.getRotation());
     Vector_t<double, 3> pmean = pc->getMeanP();
 
     double meanEnergy   = pc->getMeanKineticEnergy();
     double energySpread = pc->getStdKineticEnergy();
-    double I_0 =
-        4.0 * Physics::pi * Physics::epsilon_0 * Physics::c * pc->getTotalMass() / pc->getTotalCharge();
+    double I_0          = 4.0 * Physics::pi * Physics::epsilon_0 * Physics::c * pc->getTotalMass()
+                 / pc->getTotalCharge();
     double sigma = ((xsigma[0] * xsigma[0]) + (xsigma[1] * xsigma[1]))
                    / (2.0 * pc->getMeanGammaZ() * I_0
                       * (geomvareps[0] * geomvareps[0] + geomvareps[1] * geomvareps[1]));
 
-    //h5_int64_t localTrackStep  = (h5_int64_t)bunch->getLocalTrackStep();
+    // h5_int64_t localTrackStep  = (h5_int64_t)bunch->getLocalTrackStep();
     h5_int64_t globalTrackStep = (h5_int64_t)bunch->getGlobalTrackStep();
 
     double mass   = Units::eV2GeV * pc->getTotalMass();
@@ -374,7 +372,7 @@ void H5PartWrapperForPT::writeStepHeader(
     WRITESTEPATTRIB(Float64, file_m, "maxP", (h5_float64_t*)&maxP, 3);
 
     WRITESTEPATTRIB(Int64, file_m, "Step", &numSteps_m, 1);
-    //WRITESTEPATTRIB(Int64, file_m, "LocalTrackStep", &localTrackStep, 1);
+    // WRITESTEPATTRIB(Int64, file_m, "LocalTrackStep", &localTrackStep, 1);
     WRITESTEPATTRIB(Int64, file_m, "GlobalTrackStep", &globalTrackStep, 1);
 
     WRITESTEPATTRIB(Float64, file_m, "#sigma", &sigma, 1);
@@ -395,11 +393,11 @@ void H5PartWrapperForPT::writeStepHeader(
 
     try {
         Vector_t<double, 3> referenceB(
-            additionalStepAttributes.at("B-ref_x"), additionalStepAttributes.at("B-ref_z"),
-            additionalStepAttributes.at("B-ref_y"));
+                additionalStepAttributes.at("B-ref_x"), additionalStepAttributes.at("B-ref_z"),
+                additionalStepAttributes.at("B-ref_y"));
         Vector_t<double, 3> referenceE(
-            additionalStepAttributes.at("E-ref_x"), additionalStepAttributes.at("E-ref_z"),
-            additionalStepAttributes.at("E-ref_y"));
+                additionalStepAttributes.at("E-ref_x"), additionalStepAttributes.at("E-ref_z"),
+                additionalStepAttributes.at("E-ref_y"));
 
         WRITESTEPATTRIB(Float64, file_m, "B-ref", (h5_float64_t*)&referenceB, 3);
         WRITESTEPATTRIB(Float64, file_m, "E-ref", (h5_float64_t*)&referenceE, 3);
@@ -407,21 +405,20 @@ void H5PartWrapperForPT::writeStepHeader(
         *ippl::Error << m.what() << endl;
 
         throw OpalException(
-            "H5PartWrapperForPC::writeStepHeader", "some additional step attribute not found");
+                "H5PartWrapperForPC::writeStepHeader", "some additional step attribute not found");
     }
 
     ++numSteps_m;
 }
 
 void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContainerIndex) {
-
     auto pc                  = bunch->getParticleContainer(particleContainerIndex);
     size_t numLocalParticles = pc->getLocalNum();
 
     auto rViewDevice = pc->R.getView();
-    auto rView = Kokkos::create_mirror_view(rViewDevice);
-    Kokkos::deep_copy(rView,rViewDevice);
-    
+    auto rView       = Kokkos::create_mirror_view(rViewDevice);
+    Kokkos::deep_copy(rView, rViewDevice);
+
     REPORTONERROR(H5PartSetNumParticles(file_m, (h5_size_t)numLocalParticles));
     std::vector<char> buffer(numLocalParticles * sizeof(h5_float64_t));
     char* buffer_ptr        = Util::c_data(buffer);
@@ -442,10 +439,10 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
     WRITEDATA(Float64, file_m, "z", f64buffer);
 
     auto pViewDevice = pc->P.getView();
-    auto pView = Kokkos::create_mirror_view(pViewDevice);
-    Kokkos::deep_copy(pView,pViewDevice);
- 
-    for (long unsigned i = 0; i < numLocalParticles; i++) 
+    auto pView       = Kokkos::create_mirror_view(pViewDevice);
+    Kokkos::deep_copy(pView, pViewDevice);
+
+    for (long unsigned i = 0; i < numLocalParticles; i++)
         f64buffer[i] = pView(i)(0);
     WRITEDATA(Float64, file_m, "px", f64buffer);
 
@@ -473,19 +470,17 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
     }
     WRITEDATA(Float64, file_m, "q", f64buffer);
 
-
-    auto idViewDevice  = bunch->getParticleContainer()->ID.getView();
-    auto idView = Kokkos::create_mirror_view(idViewDevice);
-    Kokkos::deep_copy(idView,idViewDevice);
+    auto idViewDevice = bunch->getParticleContainer()->ID.getView();
+    auto idView       = Kokkos::create_mirror_view(idViewDevice);
+    Kokkos::deep_copy(idView, idViewDevice);
 
     for (long unsigned i = 0; i < numLocalParticles; i++)
         i64buffer[i] = idView(i);
     WRITEDATA(Int64, file_m, "id", i64buffer);
 
-
     auto binViewDevice = pc->Bin.getView();
-    auto binView = Kokkos::create_mirror_view(binViewDevice);
-    Kokkos::deep_copy(binView,binViewDevice);
+    auto binView       = Kokkos::create_mirror_view(binViewDevice);
+    Kokkos::deep_copy(binView, binViewDevice);
 
     for (size_t i = 0; i < numLocalParticles; ++i)
         i32buffer[i] = binView(i);
@@ -495,12 +490,11 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
     for (size_t i = 0; i < numLocalParticles; ++i)
         i32buffer[i] = sp;
     WRITEDATA(Int32, file_m, "sp", i32buffer);
-    
+
     if (Options::ebDump) {
-        
         auto EViewDevice = pc->E.getView();
-        auto EView = Kokkos::create_mirror_view(EViewDevice);
-        Kokkos::deep_copy(EView,EViewDevice);
+        auto EView       = Kokkos::create_mirror_view(EViewDevice);
+        Kokkos::deep_copy(EView, EViewDevice);
 
         for (size_t i = 0; i < numLocalParticles; ++i)
             f64buffer[i] = EView(i)(0);
@@ -515,8 +509,8 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
         WRITEDATA(Float64, file_m, "Ez", f64buffer);
 
         auto BViewDevice = pc->B.getView();
-        auto BView = Kokkos::create_mirror_view(BViewDevice);
-        Kokkos::deep_copy(BView,BViewDevice);
+        auto BView       = Kokkos::create_mirror_view(BViewDevice);
+        Kokkos::deep_copy(BView, BViewDevice);
 
         for (size_t i = 0; i < numLocalParticles; ++i)
             f64buffer[i] = BView(i)(0);
@@ -530,7 +524,7 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
             f64buffer[i] = BView(i)(2);
         WRITEDATA(Float64, file_m, "Bz", f64buffer);
     }
-    
+
     /*
     /// Write space charge field map if asked for.
     if (Options::rhoDump) {

--- a/src/Structure/H5PartWrapperForPT.cpp
+++ b/src/Structure/H5PartWrapperForPT.cpp
@@ -426,7 +426,7 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
     std::vector<char> buffer(numLocalParticles * sizeof(h5_float64_t));
     char* buffer_ptr        = Util::c_data(buffer);
     h5_float64_t* f64buffer = reinterpret_cast<h5_float64_t*>(buffer_ptr);
-    //    h5_int64_t* i64buffer   = reinterpret_cast<h5_int64_t*>(buffer_ptr);
+    h5_int64_t* i64buffer   = reinterpret_cast<h5_int64_t*>(buffer_ptr);
     h5_int32_t* i32buffer   = reinterpret_cast<h5_int32_t*>(buffer_ptr);
 
     for (size_t i = 0; i < numLocalParticles; ++i)
@@ -474,17 +474,15 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
     WRITEDATA(Float64, file_m, "q", f64buffer);
 
 
-    /*   
-
     auto idViewDevice  = bunch->getParticleContainer()->ID.getView();
     auto idView = Kokkos::create_mirror_view(idViewDevice);
     Kokkos::deep_copy(idView,idViewDevice);
-      
+
     for (long unsigned i = 0; i < numLocalParticles; i++)
         i64buffer[i] = idView(i);
     WRITEDATA(Int64, file_m, "id", i64buffer);
-    */
-    
+
+
     auto binViewDevice = pc->Bin.getView();
     auto binView = Kokkos::create_mirror_view(binViewDevice);
     Kokkos::deep_copy(binView,binViewDevice);

--- a/unit_tests/PartBunch/TestParticleContainer.cpp
+++ b/unit_tests/PartBunch/TestParticleContainer.cpp
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -564,6 +565,29 @@ namespace {
         Kokkos::View<bool*> short_invalid(
                 "DestroyParticlesTest::short_invalid", pc->getLocalNum() - 1);
         EXPECT_THROW(pc->destroyParticles(short_invalid, 0u), OpalException);
+    }
+
+    // ================================================================
+    // ID assignment — IDs follow the IPPL strided rank-interleave scheme
+    // ================================================================
+
+    TEST_F(ParticleContainerTest, CreateParticles_AssignsStridedIDs) {
+        Options::useQMAttributes = false;
+        auto pc                  = makeContainer();
+
+        constexpr size_t nPart = 32;
+        pc->createParticles(nPart);
+        ASSERT_EQ(pc->getLocalNum(), nPart);
+
+        auto idHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), pc->ID.getView());
+
+        const auto rank   = static_cast<std::int64_t>(ippl::Comm->rank());
+        const auto nRanks = static_cast<std::int64_t>(ippl::Comm->size());
+
+        for (size_t i = 0; i < nPart; ++i) {
+            EXPECT_EQ(idHost(i), rank + nRanks * static_cast<std::int64_t>(i))
+                    << "particle " << i;
+        }
     }
 
 }  // namespace

--- a/unit_tests/PartBunch/TestParticleContainer.cpp
+++ b/unit_tests/PartBunch/TestParticleContainer.cpp
@@ -585,8 +585,7 @@ namespace {
         const auto nRanks = static_cast<std::int64_t>(ippl::Comm->size());
 
         for (size_t i = 0; i < nPart; ++i) {
-            EXPECT_EQ(idHost(i), rank + nRanks * static_cast<std::int64_t>(i))
-                    << "particle " << i;
+            EXPECT_EQ(idHost(i), rank + nRanks * static_cast<std::int64_t>(i)) << "particle " << i;
         }
     }
 


### PR DESCRIPTION
closes #405 
closes #73 

This PR activates particle IDs in OPALX by explicitly passing the `Kokkos::DefaultExecutionSpace::memory_space` template to every `ParticleContainer` instance (and parent `ParticleBase` definition) and adds a unit tests for the IDs. 

Apart from that I also went ahead and added the IDs back into the H5 writer (as it was before, see #73). 