### PR TITLE
Add `InvalidMask` as particle attribute

### DIFF
--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -139,7 +139,7 @@ public:
     typename Base::particle_position_type B;
 
     /// particle deletion mask (indicates which particles are deleted every timestep)
-    ippl::ParticleAttrib<bool> invalidMask;
+    ippl::ParticleAttrib<bool> InvalidMask;
 
     ParticleContainer(Mesh_t<Dim>& mesh, FieldLayout_t<Dim>& FL)
         : pl_m(FL, mesh),
@@ -166,7 +166,7 @@ public:
         this->addAttribute(P);
         this->addAttribute(E);
         this->addAttribute(B);
-        this->addAttribute(invalidMask);
+        this->addAttribute(InvalidMask);
         if (qmStorageMode_m == QMStorageMode::Attributes) {
             this->addAttribute(QAttr);
             this->addAttribute(MAttr);

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -138,6 +138,9 @@ public:
     /// magnetic field at particle position
     typename Base::particle_position_type B;
 
+    /// particle deletion mask (indicates which particles are deleted every timestep)
+    ippl::ParticleAttrib<bool> invalidMask;
+
     ParticleContainer(Mesh_t<Dim>& mesh, FieldLayout_t<Dim>& FL)
         : pl_m(FL, mesh),
           qmStorageMode_m(
@@ -163,7 +166,7 @@ public:
         this->addAttribute(P);
         this->addAttribute(E);
         this->addAttribute(B);
-
+        this->addAttribute(invalidMask);
         if (qmStorageMode_m == QMStorageMode::Attributes) {
             this->addAttribute(QAttr);
             this->addAttribute(MAttr);


### PR DESCRIPTION
Add the `InvalidMask` attribute to the `ParticleContainer`. 

The mask isn't integrated yet and doesn't do anything, but can already be used for the developement of #395 and `LossDataSink`. How this will be used is explained in #404, but I'll make a separate PR for that later.  