### PR TITLE
Fix binary repartition exception call (some multirank tests) and introduce `STEPINFOFQ` option

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,13 +5,18 @@ on:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches: ["master"]
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     name: Check
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     steps:
       - name: Checkout repository
@@ -62,4 +67,3 @@ jobs:
           done <<'EOF'
           ${{ steps.files.outputs.files }}
           EOF
-

--- a/.github/workflows/cpu-openmp.yml
+++ b/.github/workflows/cpu-openmp.yml
@@ -6,7 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -14,7 +14,10 @@ jobs:
   build:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cpu-serial.yml
+++ b/.github/workflows/cpu-serial.yml
@@ -6,7 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -14,7 +14,10 @@ jobs:
   build:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cpu-serial.yml
+++ b/.github/workflows/cpu-serial.yml
@@ -6,6 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
+  # Give each PR a unique concurrency group 
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/gpu-cuda.yml
+++ b/.github/workflows/gpu-cuda.yml
@@ -6,7 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -15,7 +15,10 @@ jobs:
   build:
     name: Compile
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     container:
       image: nvidia/cuda:13.1.0-devel-ubuntu24.04

--- a/.github/workflows/gpu-hip.yml
+++ b/.github/workflows/gpu-hip.yml
@@ -6,7 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -15,7 +15,10 @@ jobs:
   build:
     name: Compile
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     container:
       image: rocm/dev-ubuntu-22.04:7.2

--- a/.github/workflows/gpu-sycl.yml
+++ b/.github/workflows/gpu-sycl.yml
@@ -6,7 +6,7 @@ on:
     branches: ["master"]
 
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}-${{ contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false && (github.event.action != 'labeled' || github.event.label.name == 'compile-ci') && 'ci' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -15,7 +15,10 @@ jobs:
   build:
     name: Compile SYCL
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'compile-ci') && github.event.pull_request.draft == false
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'compile-ci') &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'compile-ci')
 
     container:
       image: intel/oneapi-basekit:latest

--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -641,7 +641,7 @@ void ParallelTracker::computeSpaceChargeFields(unsigned long long step) {
     // TODO: itsBunch_m->boundp() not implemented yet.
     // itsBunch_m->boundp();
 
-    if (step % repartFreq_m + 1 == repartFreq_m) {
+    if (repartFreq_m > 0 && step % repartFreq_m + 1 == repartFreq_m) {
         doBinaryRepartition();
         m << level4 << "Binary repartition done." << endl;
     }
@@ -999,17 +999,10 @@ void ParallelTracker::activateEmittingContainers(double t) {
  */
 void ParallelTracker::doBinaryRepartition() {
     Inform m("ParallelTracker::doBinaryRepartition");
-    if (itsBunch_m->hasFieldSolver()) {
-        m << level4 << "*****************************************************************" << endl;
-        m << level4 << "do repartition because of repartFreq_m" << endl;
-        m << level4 << "*****************************************************************" << endl;
-        itsBunch_m->do_binaryRepart();
-        ippl::Comm->barrier();
-        IpplTimings::stopTimer(BinRepartTimer_m);
-        m << level4 << "*****************************************************************" << endl;
-        m << level3 << "do repartition done" << endl;
-        m << level4 << "*****************************************************************" << endl;
-    }
+    m << level2
+      << "Binary load-balancer repartition is disabled while the ORB path is "
+         "not wired for the current multi-container bunch state; skipping."
+      << endl;
 }
 
 /**
@@ -1267,12 +1260,17 @@ void ParallelTracker::findStartPositions(const BorisPusher& pusher) {
 void ParallelTracker::dumpStats(long long step, bool psDump, bool statDump) {
     OPALTimer::Timer myt2;
     const size_t totalAll = itsBunch_m->getTotalNumAllContainers();
+    const long long globalStep = itsBunch_m->getGlobalTrackStep();
+    const bool printStepInfo =
+            Options::stepInfoFreq > 0 && globalStep % Options::stepInfoFreq == 0;
 
     if (totalAll == 0) {
-        *gmsg << level1 << "* " << myt2.time() << " "
-              << "Step " << std::setw(6) << itsBunch_m->getGlobalTrackStep() << "; "
-              << "   -- no emission yet --     "
-              << "t= " << Util::getTimeString(itsBunch_m->getT()) << endl;
+        if (printStepInfo) {
+            *gmsg << level1 << "* " << myt2.time() << " "
+                  << "Step " << std::setw(6) << globalStep << "; "
+                  << "   -- no emission yet --     "
+                  << "t= " << Util::getTimeString(itsBunch_m->getT()) << endl;
+        }
         return;
     }
 
@@ -1290,12 +1288,14 @@ void ParallelTracker::dumpStats(long long step, bool psDump, bool statDump) {
                     "ParallelTracker::dumpStats()",
                     "invalid path length s for particle container " + std::to_string(ci));
         }
-        *gmsg << level1 << "* " << myt2.time() << " "
-              << "Step " << std::setw(6) << itsBunch_m->getGlobalTrackStep() << " "
-              << "container[" << ci << "] "
-              << "at " << Util::getLengthString(sPos) << ", "
-              << "t= " << Util::getTimeString(itsBunch_m->getT()) << ", "
-              << "E=" << Util::getEnergyString(pc->getMeanKineticEnergy()) << endl;
+        if (printStepInfo) {
+            *gmsg << level1 << "* " << myt2.time() << " "
+                  << "Step " << std::setw(6) << globalStep << " "
+                  << "container[" << ci << "] "
+                  << "at " << Util::getLengthString(sPos) << ", "
+                  << "t= " << Util::getTimeString(itsBunch_m->getT()) << ", "
+                  << "E=" << Util::getEnergyString(pc->getMeanKineticEnergy()) << endl;
+        }
         anyLogged = true;
     }
 
@@ -1318,15 +1318,26 @@ void ParallelTracker::setOptionalVariables() {
     */
     Inform m("ParallelTracker::setOptionalVariables");
 
-    // there is no point to do repartitioning with one node
+    repartFreq_m = 0;
+
+    // The ORB load-balancer path is not currently wired to the unified
+    // multi-container bunch state. Keep REPARTFREQ accepted for input
+    // compatibility, but do not schedule the disabled path.
     if (ippl::Comm->size() == 1) {
-        repartFreq_m = std::numeric_limits<unsigned long long>::max();
+        m << level3 << "Binary load-balancer repartition disabled on one rank." << endl;
     } else {
-        repartFreq_m = Options::repartFreq * 100;
+        long long requestedRepartFreq = static_cast<long long>(Options::repartFreq) * 100;
         RealVariable* rep =
                 dynamic_cast<RealVariable*>(OpalData::getInstance()->find("REPARTFREQ"));
-        if (rep) repartFreq_m = static_cast<int>(rep->getReal());
-        m << level3 << "REPARTFREQ set to " << repartFreq_m << "." << endl;
+        if (rep) {
+            requestedRepartFreq = static_cast<long long>(rep->getReal());
+        }
+        if (requestedRepartFreq > 0) {
+            m << level2 << "REPARTFREQ = " << requestedRepartFreq
+              << " requested, but binary load-balancer repartition is disabled." << endl;
+        } else {
+            m << level3 << "Binary load-balancer repartition disabled." << endl;
+        }
     }
 }
 
@@ -1392,7 +1403,7 @@ void ParallelTracker::writePhaseSpace(const long long /*step*/, bool psDump, boo
 
     if (statDump) {
         itsDataSink_m->dumpSDDS(*itsBunch_m, fdByContainer, -1.0);
-        *gmsg << level2 << "* Wrote beam statistics." << endl;
+        *gmsg << level3 << "* Wrote beam statistics." << endl;
     }
 
     if (psDump && itsBunch_m->getTotalNumAllContainers() > 0) {

--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -1259,10 +1259,9 @@ void ParallelTracker::findStartPositions(const BorisPusher& pusher) {
  */
 void ParallelTracker::dumpStats(long long step, bool psDump, bool statDump) {
     OPALTimer::Timer myt2;
-    const size_t totalAll = itsBunch_m->getTotalNumAllContainers();
+    const size_t totalAll      = itsBunch_m->getTotalNumAllContainers();
     const long long globalStep = itsBunch_m->getGlobalTrackStep();
-    const bool printStepInfo =
-            Options::stepInfoFreq > 0 && globalStep % Options::stepInfoFreq == 0;
+    const bool printStepInfo = Options::stepInfoFreq > 0 && globalStep % Options::stepInfoFreq == 0;
 
     if (totalAll == 0) {
         if (printStepInfo) {

--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -1319,9 +1319,10 @@ void ParallelTracker::setOptionalVariables() {
 
     repartFreq_m = 0;
 
-    // The ORB load-balancer path is not currently wired to the unified
-    // multi-container bunch state. Keep REPARTFREQ accepted for input
-    // compatibility, but do not schedule the disabled path.
+    // ORB repartitioning is a per-container operation, but PartBunch currently
+    // only passes the primary container to LoadBalancer. Until the load
+    // balancer handles every particle container, keep REPARTFREQ accepted for
+    // input compatibility but do not schedule the disabled repartition operation.
     if (ippl::Comm->size() == 1) {
         m << level3 << "Binary load-balancer repartition disabled on one rank." << endl;
     } else {

--- a/src/Algorithms/ParallelTracker.h
+++ b/src/Algorithms/ParallelTracker.h
@@ -78,7 +78,7 @@ private:
     StepSizeConfig stepSizes_m;
 
     double dtCurrentTrack_m;          ///< Global @f$\Delta t@f$ for the current track segment.
-    unsigned long long repartFreq_m;  ///< Space-charge repartition period (steps); off on one rank.
+    unsigned long long repartFreq_m;  ///< Space-charge repartition period (steps); 0 disables it.
     std::vector<std::vector<std::shared_ptr<SamplingBase>>>
             emittingSamplers_m;  ///< Per-container emitters.
 

--- a/src/BasicActions/Option.cpp
+++ b/src/BasicActions/Option.cpp
@@ -60,6 +60,7 @@ namespace {
         TELL,
         PSDUMPFREQ,
         STATDUMPFREQ,
+        STEPINFOFQ,
         PSDUMPEACHTURN,
         PSDUMPFRAME,
         SPTDUMPFREQ,
@@ -135,6 +136,12 @@ Option::Option()
             "(e.g. RMS beam quantities), i.e. dump data when step%statDumpFreq == 0, "
             "its default value is 10.",
             statDumpFreq);
+
+    itsAttr[STEPINFOFQ] = Attributes::makeReal(
+            "STEPINFOFQ",
+            "The frequency to print per-step tracking status lines. "
+            "A value of 0 disables these status lines; its default value is 1.",
+            stepInfoFreq);
 
     itsAttr[PSDUMPEACHTURN] = Attributes::makeBool(
             "PSDUMPEACHTURN",
@@ -352,6 +359,7 @@ Option::Option(const std::string& name, Option* parent) : Action(name, parent) {
     Attributes::setReal(itsAttr[SEED], seed);
     Attributes::setReal(itsAttr[PSDUMPFREQ], psDumpFreq);
     Attributes::setReal(itsAttr[STATDUMPFREQ], statDumpFreq);
+    Attributes::setReal(itsAttr[STEPINFOFQ], stepInfoFreq);
     Attributes::setBool(itsAttr[PSDUMPEACHTURN], psDumpEachTurn);
     Attributes::setPredefinedString(itsAttr[PSDUMPFRAME], getDumpFrameString(psDumpFrame));
     Attributes::setReal(itsAttr[SPTDUMPFREQ], sptDumpFreq);
@@ -461,6 +469,11 @@ void Option::execute() {
     if (itsAttr[STATDUMPFREQ]) {
         statDumpFreq = int(Attributes::getReal(itsAttr[STATDUMPFREQ]));
         if (statDumpFreq == 0) statDumpFreq = std::numeric_limits<int>::max();
+    }
+
+    if (itsAttr[STEPINFOFQ]) {
+        stepInfoFreq = int(Attributes::getReal(itsAttr[STEPINFOFQ]));
+        if (stepInfoFreq < 0) stepInfoFreq = 0;
     }
 
     if (itsAttr[SPTDUMPFREQ]) {

--- a/src/PartBunch/PartBunch.cpp
+++ b/src/PartBunch/PartBunch.cpp
@@ -215,22 +215,11 @@ void PartBunch<T, Dim>::refreshPcActiveAfterEmit() {
  */
 template <typename T, unsigned Dim>
 void PartBunch<T, Dim>::do_binaryRepart() {
-    throw OpalException(
-            "PartBunch::do_binaryRepart",
-            "Not implemented yet. The load-balancer repartition path is still being "
-            "re-wired against the unified BunchStateHandler and multi-container "
-            "setup; callers must not invoke this until it is properly hooked up.");
-
-    using FieldContainer_t               = FieldContainer<T, Dim>;
-    std::shared_ptr<FieldContainer_t> fc = this->fcontainer_m;
-
-    size_type totalP = this->getParticleContainer()->getTotalNum();
-
-    if (this->loadbalancer_m->balance(totalP)) {
-        auto* mesh = &fc->getRho().get_mesh();
-        auto* FL   = &fc->getFL();
-        this->loadbalancer_m->repartition(FL, mesh, isFirstRepartition_m);
-    }
+    Inform m("PartBunch::do_binaryRepart");
+    m << level2
+      << "Binary load-balancer repartition is disabled while the ORB path is "
+         "not wired for the current multi-container bunch state; skipping."
+      << endl;
 }
 
 /**
@@ -581,9 +570,7 @@ void PartBunch<T, Dim>::bunchUpdate() {
     applyGridUpdate(lower, upper);
 
     isFirstRepartition_m = true;
-    // this->loadbalancer_m->initializeORB(FL, mesh);
-    // this->loadbalancer_m->repartition(FL, mesh, isFirstRepartition_m);
-    m << level5 << "Load balancer repartitioning done." << endl;
+    m << level5 << "Bunch grid update done without load-balancer repartitioning." << endl;
 
     // Always request moments update; DistributionMoments decides whether it
     // actually needs to recompute based on the dirty flag.

--- a/src/Utilities/Options.cpp
+++ b/src/Utilities/Options.cpp
@@ -40,6 +40,8 @@ namespace Options {
 
     int statDumpFreq = 10;
 
+    int stepInfoFreq = 1;
+
     bool psDumpEachTurn = false;
 
     DumpFrame psDumpFrame = DumpFrame::GLOBAL;

--- a/src/Utilities/Options.h
+++ b/src/Utilities/Options.h
@@ -56,6 +56,9 @@ namespace Options {
     /// The frequency to dump statistical values, e.e. dump data when step%statDumpFreq==0
     extern int statDumpFreq;
 
+    /// The frequency to print per-step tracking status lines; 0 disables them.
+    extern int stepInfoFreq;
+
     /// phase space dump flag for OPAL-cycl
     //  if true, dump phase space after each turn
     extern bool psDumpEachTurn;


### PR DESCRIPTION
While trying out multi rank regression tests, I noticed that they fail, since I previously added an exception should the binary repartition routine be called. However, since some tests (like `FODO`) called it anyway (the function calls are wired into OPALX, just no-ops), I fixed it by writing a generic warning to the console and not a hard exception. 

## Summary
Disable the currently unwired binary load-balancer repartition path while preserving `REPARTFREQ` input "compatibility". Repartition requests now log and skip safely instead of calling incomplete ORB/multi-container logic.

Add a new `STEPINFOFQ` option to control per-step tracking status output, including support for `0` to silence those lines. Beam statistics dump logging is also lowered in verbosity.

## Changes
- Disable scheduled binary repartitioning and guard against zero repartition frequency.
- Convert `PartBunch::do_binaryRepart()` from an exception path to a logged no-op.
- Add `Options::stepInfoFreq` and expose it through `OPTION, STEPINFOFQ`.
- Gate tracker step-status lines on `STEPINFOFQ`.

> FYI: I did the second change with `STEPINFOFQ`, since huge simulations with thousands of steps (`AWAGun`) then have unnecessarily verbose logs. Old OPAL also has a mechanism that automatically only prints every 100th step for `AWAGun`. 

Edit: also did a little fix to the workflows. With multiple labels, they always triggered multiple runs for each config, then deleted the old ones and only kept the newest. That's unnecessary, now they are only triggered once for every action by giving them their own concurrency group. 