### PR TITLE
Support `Astra1DDynamic` fieldmaps in `RFCavity`

### DIFF
--- a/src/AbsBeamline/RFCavity.cpp
+++ b/src/AbsBeamline/RFCavity.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include "AbsBeamline/BeamlineVisitor.h"
 #include "Component.h"
+#include "Fields/Astra1DDynamic.h"
 #include "Fields/FM2DDynamic.h"
 #include "Fields/Fieldmap.h"
 #include "PartBunch/PartBunch.h"
@@ -132,14 +133,19 @@ bool RFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     const double cosphi = Kokkos::cos(phi);
     const double sinphi = Kokkos::sin(phi);
 
-    auto* dynamicFieldmap = dynamic_cast<FM2DDynamic*>(fieldmap_m);
-    if (dynamicFieldmap == nullptr) {
+    const double electricScale = scale * cosphi;
+    const double magneticScale = -scale * sinphi;
+
+    if (auto* dynamicFieldmap = dynamic_cast<FM2DDynamic*>(fieldmap_m)) {
+        dynamicFieldmap->applyRFField(pc, electricScale, magneticScale, startField, endField);
+    } else if (auto* astraFieldmap = dynamic_cast<Astra1DDynamic*>(fieldmap_m)) {
+        astraFieldmap->applyRFField(pc, electricScale, magneticScale, startField, endField);
+    } else {
         throw GeneralOpalException(
                 "RFCavity::apply",
-                "RFCavity particle application currently requires an FM2DDynamic field map.");
+                "RFCavity particle application currently requires an FM2DDynamic or Astra1DDynamic "
+                "field map.");
     }
-
-    dynamicFieldmap->applyRFField(pc, scale * cosphi, -scale * sinphi, startField, endField);
 
     return false;
 }

--- a/src/Fields/Astra1DDynamic.cpp
+++ b/src/Fields/Astra1DDynamic.cpp
@@ -306,6 +306,38 @@ void Astra1DDynamic::applyField(std::shared_ptr<ParticleContainer_t> pc, double)
             });
 }
 
+void Astra1DDynamic::applyRFField(
+        std::shared_ptr<ParticleContainer_t> pc, double electricScale, double magneticScale,
+        double startField, double endField) {
+    const double zbegin = zbegin_m;
+    const double zend   = zend_m;
+    const double length = length_m;
+    const double xlrep  = xlrep_m;
+    const int accuracy  = accuracy_m;
+
+    auto FourCoefs_device = FourCoefs_m.view_device();
+
+    auto Rview = pc->R.getView();
+    auto Eview = pc->E.getView();
+    auto Bview = pc->B.getView();
+
+    const size_t nLocal = pc->getLocalNum();
+
+    Kokkos::parallel_for(
+            "Astra1DDynamic::applyRFField", nLocal, KOKKOS_LAMBDA(const size_t i) {
+                const auto& R = Rview(i);
+
+                if (R(2) >= startField && R(2) < endField && R(2) >= zbegin && R(2) < zend) {
+                    Vector_t<double, 3> tmpE(0.0), tmpB(0.0);
+
+                    computeField(R, tmpE, tmpB, FourCoefs_device, zbegin, length, xlrep, accuracy);
+
+                    Eview(i) += electricScale * tmpE;
+                    Bview(i) += magneticScale * tmpB;
+                }
+            });
+}
+
 void Astra1DDynamic::applyTravelingWave(
         std::shared_ptr<ParticleContainer_t> pc, double entryElectricScale,
         double entryMagneticScale, double core1ElectricScale, double core1MagneticScale,

--- a/src/Fields/Astra1DDynamic.cpp
+++ b/src/Fields/Astra1DDynamic.cpp
@@ -325,16 +325,9 @@ void Astra1DDynamic::applyRFField(
 
     Kokkos::parallel_for(
             "Astra1DDynamic::applyRFField", nLocal, KOKKOS_LAMBDA(const size_t i) {
-                const auto& R = Rview(i);
-
-                if (R(2) >= startField && R(2) < endField && R(2) >= zbegin && R(2) < zend) {
-                    Vector_t<double, 3> tmpE(0.0), tmpB(0.0);
-
-                    computeField(R, tmpE, tmpB, FourCoefs_device, zbegin, length, xlrep, accuracy);
-
-                    Eview(i) += electricScale * tmpE;
-                    Bview(i) += magneticScale * tmpB;
-                }
+                computeRFField(
+                        Rview(i), Eview(i), Bview(i), FourCoefs_device, zbegin, zend, length, xlrep,
+                        accuracy, electricScale, magneticScale, startField, endField);
             });
 }
 

--- a/src/Fields/Astra1DDynamic.h
+++ b/src/Fields/Astra1DDynamic.h
@@ -1,5 +1,5 @@
-#ifndef CLASSIC_AstraFIELDMAP1DDYNAMIC_HH
-#define CLASSIC_AstraFIELDMAP1DDYNAMIC_HH
+#ifndef OPALX_AstraFIELDMAP1DDYNAMIC_HH
+#define OPALX_AstraFIELDMAP1DDYNAMIC_HH
 
 #include "Fields/Fieldmap.h"
 #include "Physics/Physics.h"
@@ -202,6 +202,22 @@ public:
      * @param pc Particle container
      */
     void applyField(std::shared_ptr<ParticleContainer_t> pc, double) override;
+
+    /**
+     * @brief Apply RF-scaled Astra1DDynamic field to all particles.
+     *
+     * Used by RFCavity. The static fieldmap is evaluated on device and then
+     * scaled with the RF electric and magnetic phase factors.
+     *
+     * @param pc Particle container.
+     * @param electricScale Scale factor applied to E.
+     * @param magneticScale Scale factor applied to B.
+     * @param startField Longitudinal start of the cavity field region.
+     * @param endField Longitudinal end of the cavity field region.
+     */
+    void applyRFField(
+            std::shared_ptr<ParticleContainer_t> pc, double electricScale, double magneticScale,
+            double startField, double endField);
 
     /**
      * @brief Apply the traveling-wave RF field map to all particles.

--- a/src/Fields/Astra1DDynamic.h
+++ b/src/Fields/Astra1DDynamic.h
@@ -131,6 +131,28 @@ public:
     }
 
     template <class ViewType>
+    KOKKOS_INLINE_FUNCTION static void computeRFField(
+            const Vector_t<double, 3>& R, Vector_t<double, 3>& E, Vector_t<double, 3>& B,
+            const ViewType& FourCoefs, double zbegin, double zend, double length, double xlrep,
+            int accuracy, double electricScale, double magneticScale, double startField,
+            double endField) {
+        if (R(2) < startField || R(2) >= endField) {
+            return;
+        }
+
+        if (R(2) < zbegin || R(2) >= zend) {
+            return;
+        }
+
+        Vector_t<double, 3> tmpE(0.0), tmpB(0.0);
+
+        computeField(R, tmpE, tmpB, FourCoefs, zbegin, length, xlrep, accuracy);
+
+        E += electricScale * tmpE;
+        B += magneticScale * tmpB;
+    }
+
+    template <class ViewType>
     KOKKOS_INLINE_FUNCTION static void computeTravelingWaveField(
             const Vector_t<double, 3>& R, Vector_t<double, 3>& E, Vector_t<double, 3>& B,
             const ViewType& FourCoefs, double zbegin, double zend, double length, double xlrep,

--- a/unit_tests/Fields/TestAstra1DDynamic.cpp
+++ b/unit_tests/Fields/TestAstra1DDynamic.cpp
@@ -14,7 +14,8 @@
  * - Uniform on-axis field correctness
  * - Static computeField() correctness for simple coefficients
  * - Reconstructed on-axis field via getOnaxisEz()
- * - Device-safe traveling-wave application via applyTravelingWave()
+ * - Device-safe RF cavity helper via computeRFField()
+ * - Device-safe traveling-wave helper via computeTravelingWaveField()
  *
  * Geometry & bounds:
  * - Behaviour outside z-range
@@ -643,6 +644,111 @@ TEST_F(Astra1DDynamicTest, ComputeTravelingWaveFieldOutsideRange) {
     EXPECT_NEAR(E[0], 1.0, 1e-12);
     EXPECT_NEAR(E[1], 2.0, 1e-12);
     EXPECT_NEAR(E[2], 3.0, 1e-12);
+    EXPECT_NEAR(B[0], 4.0, 1e-12);
+    EXPECT_NEAR(B[1], 5.0, 1e-12);
+    EXPECT_NEAR(B[2], 6.0, 1e-12);
+}
+
+// ===========================================================================
+// Test: computeRFField applies RF scaling inside longitudinal range
+// ===========================================================================
+TEST_F(Astra1DDynamicTest, ComputeRFFieldInsideRange) {
+    Kokkos::View<double*, Kokkos::HostSpace> coefs("coefs", 3);
+    coefs(0) = 1.0;
+    coefs(1) = 0.0;
+    coefs(2) = 0.0;
+
+    Vector_t<double, 3> R = {0.0, 0.0, 0.05};
+    Vector_t<double, 3> E = {0.0, 0.0, 0.0};
+    Vector_t<double, 3> B = {0.0, 0.0, 0.0};
+
+    Astra1DDynamic::computeRFField(
+            R, E, B, coefs,
+            0.0,   // zbegin
+            0.10,  // zend
+            0.20,  // length
+            1.0,   // xlrep
+            2,     // accuracy
+            2.0,   // electricScale
+            0.0,   // magneticScale
+            0.0,   // startField
+            0.10   // endField
+    );
+
+    EXPECT_NEAR(E[0], 0.0, 1e-12);
+    EXPECT_NEAR(E[1], 0.0, 1e-12);
+    EXPECT_NEAR(E[2], 2.0, 1e-12);
+
+    EXPECT_NEAR(B[0], 0.0, 1e-12);
+    EXPECT_NEAR(B[1], 0.0, 1e-12);
+    EXPECT_NEAR(B[2], 0.0, 1e-12);
+}
+
+// ===========================================================================
+// Test: computeRFField does nothing outside RFCavity longitudinal range
+// ===========================================================================
+TEST_F(Astra1DDynamicTest, ComputeRFFieldOutsideStartEndRange) {
+    Kokkos::View<double*, Kokkos::HostSpace> coefs("coefs", 3);
+    coefs(0) = 1.0;
+    coefs(1) = 0.0;
+    coefs(2) = 0.0;
+
+    Vector_t<double, 3> R = {0.0, 0.0, 0.05};
+    Vector_t<double, 3> E = {1.0, 2.0, 3.0};
+    Vector_t<double, 3> B = {4.0, 5.0, 6.0};
+
+    Astra1DDynamic::computeRFField(
+            R, E, B, coefs,
+            0.0,   // zbegin
+            0.10,  // zend
+            0.20,  // length
+            1.0,   // xlrep
+            2,     // accuracy
+            2.0,   // electricScale
+            3.0,   // magneticScale
+            0.06,  // startField
+            0.10   // endField
+    );
+
+    EXPECT_NEAR(E[0], 1.0, 1e-12);
+    EXPECT_NEAR(E[1], 2.0, 1e-12);
+    EXPECT_NEAR(E[2], 3.0, 1e-12);
+
+    EXPECT_NEAR(B[0], 4.0, 1e-12);
+    EXPECT_NEAR(B[1], 5.0, 1e-12);
+    EXPECT_NEAR(B[2], 6.0, 1e-12);
+}
+
+// ===========================================================================
+// Test: computeRFField does nothing outside fieldmap z range
+// ===========================================================================
+TEST_F(Astra1DDynamicTest, ComputeRFFieldOutsideFieldmapRange) {
+    Kokkos::View<double*, Kokkos::HostSpace> coefs("coefs", 3);
+    coefs(0) = 1.0;
+    coefs(1) = 0.0;
+    coefs(2) = 0.0;
+
+    Vector_t<double, 3> R = {0.0, 0.0, 0.11};
+    Vector_t<double, 3> E = {1.0, 2.0, 3.0};
+    Vector_t<double, 3> B = {4.0, 5.0, 6.0};
+
+    Astra1DDynamic::computeRFField(
+            R, E, B, coefs,
+            0.0,   // zbegin
+            0.10,  // zend
+            0.20,  // length
+            1.0,   // xlrep
+            2,     // accuracy
+            2.0,   // electricScale
+            3.0,   // magneticScale
+            0.0,   // startField
+            0.20   // endField
+    );
+
+    EXPECT_NEAR(E[0], 1.0, 1e-12);
+    EXPECT_NEAR(E[1], 2.0, 1e-12);
+    EXPECT_NEAR(E[2], 3.0, 1e-12);
+
     EXPECT_NEAR(B[0], 4.0, 1e-12);
     EXPECT_NEAR(B[1], 5.0, 1e-12);
     EXPECT_NEAR(B[2], 6.0, 1e-12);


### PR DESCRIPTION
This PR extends the particle-container application path of `RFCavity` to support `Astra1DDynamic` fieldmaps in addition to the existing `FM2DDynamic` path.

Closes: https://github.com/OPALX-project/OPALX/issues/420

### Motivation

`RFCavity::apply(pc)` currently supports only `FM2DDynamic` fieldmaps. However, some cases, such as the SwissFEL RF gun, require `Astra1DDynamic` fieldmaps. This PR adds the missing support so these cases can be migrated to OPALX.

### Changes

* Added an `Astra1DDynamic::applyRFField(...)` path for RF-scaled particle application
* Added a device-callable `Astra1DDynamic::computeRFField(...)` helper
* Updated `RFCavity::apply(pc)` to dispatch to either:

  * `FM2DDynamic::applyRFField(...)`
  * `Astra1DDynamic::applyRFField(...)`
* Kept the same RF scaling convention as the existing `FM2DDynamic` path:
  * electric field scaled with `scale * cos(phi)`
  * magnetic field scaled with `-scale * sin(phi)`

### Tests

* Extended `Astra1DDynamic` unit tests for the new RF-cavity helper logic
* Verified that the existing `RFCavity` unit tests remain unchanged
* Test performed using the SwissFEL RF gun seems good
<img width="16200" height="15000" alt="Multiplot_comparison" src="https://github.com/user-attachments/assets/c0fa09a0-b68b-4dc1-8b58-66ecac80954b" />

### Notes
* Full SwissFEL regression test will follow