### PR TITLE
Add Michel + pion-decay spectrum unit tests with CSV/plot tooling

### DIFF
--- a/tools/spectrum_plots/plot_spectrum.py
+++ b/tools/spectrum_plots/plot_spectrum.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+plot_spectrum.py - Plot decay-spectrum CSVs emitted by OPALX physics unit tests.
+
+The CSV format (written by unit_tests/Physics/SpectrumTestSupport.h) is:
+
+    # x_label: <axis label string>
+    # columns: bin_low,bin_high,bin_center,density,count,analytic_pdf
+    <bin_low>,<bin_high>,<bin_center>,<density>,<count>,<analytic_pdf>
+    ...
+
+Renders the histogram density as bars with the analytic PDF overlaid.
+
+Usage:
+    python plot_spectrum.py muon_michel_spectrum.csv --out muon_michel.png
+    python plot_spectrum.py --all *.csv --outdir plots/
+
+Dependencies: numpy, matplotlib (no project-specific deps).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def parse_csv(path: Path):
+    """Return (x_label, bin_low, bin_high, bin_center, density, count, analytic)."""
+    x_label = ""
+    rows = []
+    with path.open() as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row:
+                continue
+            first = row[0]
+            if first.startswith("#"):
+                comment = ",".join(row).lstrip("#").strip()
+                if comment.startswith("x_label:"):
+                    x_label = comment.split(":", 1)[1].strip()
+                continue
+            rows.append(row)
+
+    arr = np.array(rows, dtype=float)
+    if arr.ndim != 2 or arr.shape[1] != 6:
+        raise ValueError(
+            f"{path}: expected 6 columns, got shape {arr.shape}"
+        )
+    return (
+        x_label,
+        arr[:, 0],  # bin_low
+        arr[:, 1],  # bin_high
+        arr[:, 2],  # bin_center
+        arr[:, 3],  # density
+        arr[:, 4],  # count
+        arr[:, 5],  # analytic_pdf
+    )
+
+
+def plot_one(path: Path, out: Path, dpi: int = 150) -> None:
+    x_label, lo, hi, ctr, density, count, analytic = parse_csv(path)
+
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    widths = hi - lo
+    ax.bar(
+        ctr,
+        density,
+        width=widths,
+        align="center",
+        color="#4c72b0",
+        alpha=0.55,
+        edgecolor="#1f3a68",
+        linewidth=0.6,
+        label="sampled (density)",
+    )
+    ax.plot(
+        ctr,
+        analytic,
+        color="#c0392b",
+        linewidth=2.0,
+        label="analytic PDF",
+    )
+
+    ax.set_xlabel(x_label or "x")
+    ax.set_ylabel("density")
+    ax.set_title(path.stem)
+    ax.set_xlim(lo[0], hi[-1])
+    ax.set_ylim(bottom=0.0)
+    ax.grid(True, alpha=0.3)
+    ax.legend(frameon=False)
+
+    n_total = int(count.sum())
+    ax.text(
+        0.99,
+        0.97,
+        f"N = {n_total}",
+        transform=ax.transAxes,
+        ha="right",
+        va="top",
+        fontsize=9,
+        color="#444",
+    )
+
+    fig.tight_layout()
+    fig.savefig(out, dpi=dpi)
+    plt.close(fig)
+    print(f"wrote {out}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    p.add_argument("csv", nargs="*", help="CSV file(s) to plot")
+    p.add_argument("--out", help="output PNG path (single CSV mode)")
+    p.add_argument(
+        "--outdir",
+        default=".",
+        help="output directory when plotting multiple CSVs (default: cwd)",
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        help="treat all positional arguments as CSVs and emit one PNG each",
+    )
+    p.add_argument("--dpi", type=int, default=150, help="output DPI (default 150)")
+    args = p.parse_args(argv)
+
+    if not args.csv:
+        p.error("at least one CSV file is required")
+
+    if args.all or len(args.csv) > 1:
+        outdir = Path(args.outdir)
+        outdir.mkdir(parents=True, exist_ok=True)
+        for csv_path in args.csv:
+            csv_path = Path(csv_path)
+            out = outdir / (csv_path.stem + ".png")
+            plot_one(csv_path, out, dpi=args.dpi)
+        return 0
+
+    csv_path = Path(args.csv[0])
+    out = Path(args.out) if args.out else csv_path.with_suffix(".png")
+    plot_one(csv_path, out, dpi=args.dpi)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/spectrum_plots/plot_spectrum.py
+++ b/tools/spectrum_plots/plot_spectrum.py
@@ -113,21 +113,68 @@ def plot_one(path: Path, out: Path, dpi: int = 150) -> None:
     print(f"wrote {out}")
 
 
+EXAMPLES = """\
+examples:
+  # Single CSV -> single PNG (named explicitly):
+  python plot_spectrum.py muon_michel_spectrum.csv --out muon_michel.png
+
+  # Single CSV -> single PNG (default name muon_michel_spectrum.png):
+  python plot_spectrum.py muon_michel_spectrum.csv
+
+  # Many CSVs at once, written to a target directory:
+  python plot_spectrum.py --all *.csv --outdir plots/
+
+  # Higher-resolution output:
+  python plot_spectrum.py spectrum.csv --out spectrum.png --dpi 300
+
+CSV format expected (written by unit_tests/Physics/SpectrumTestSupport.h):
+  # x_label: <axis label string>
+  # columns: bin_low,bin_high,bin_center,density,count,analytic_pdf
+  <bin_low>,<bin_high>,<bin_center>,<density>,<count>,<analytic_pdf>
+  ...
+"""
+
+
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__.split("\n")[1])
-    p.add_argument("csv", nargs="*", help="CSV file(s) to plot")
-    p.add_argument("--out", help="output PNG path (single CSV mode)")
+    p = argparse.ArgumentParser(
+        prog="plot_spectrum.py",
+        description=(
+            "Plot decay-spectrum CSVs emitted by OPALX physics unit tests. "
+            "Renders the sampled histogram density as bars with the analytic "
+            "PDF overlaid as a line."
+        ),
+        epilog=EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "csv",
+        nargs="*",
+        metavar="CSV",
+        help="one or more CSV files to plot",
+    )
+    p.add_argument(
+        "--out",
+        metavar="PATH",
+        help="output PNG path (single-CSV mode only; default: <csv>.png next to the CSV)",
+    )
     p.add_argument(
         "--outdir",
         default=".",
-        help="output directory when plotting multiple CSVs (default: cwd)",
+        metavar="DIR",
+        help="output directory when plotting multiple CSVs (default: current directory)",
     )
     p.add_argument(
         "--all",
         action="store_true",
-        help="treat all positional arguments as CSVs and emit one PNG each",
+        help="treat every positional argument as a CSV and emit one PNG each into --outdir",
     )
-    p.add_argument("--dpi", type=int, default=150, help="output DPI (default 150)")
+    p.add_argument(
+        "--dpi",
+        type=int,
+        default=150,
+        metavar="N",
+        help="output resolution in dots per inch (default: 150)",
+    )
     args = p.parse_args(argv)
 
     if not args.csv:

--- a/unit_tests/Physics/CMakeLists.txt
+++ b/unit_tests/Physics/CMakeLists.txt
@@ -18,6 +18,9 @@ add_opalx_test(TestLinearBreitWheeler USE_GTEST_MAIN)
 
 add_opalx_test(TestMuonDecay USE_GTEST_MAIN)
 
+add_opalx_test(TestMuonDecaySpectrum USE_GTEST_MAIN)
+add_opalx_test(TestPionDecaySpectrum USE_GTEST_MAIN)
+
 #add_opalx_test(TestLinearBreitWheelerSpectrum USE_GTEST_MAIN NO_MPI)
 
 add_executable(LinearBreitWheelerBenchmark LinearBreitWheelerBenchmark.cpp)

--- a/unit_tests/Physics/SpectrumTestSupport.h
+++ b/unit_tests/Physics/SpectrumTestSupport.h
@@ -1,12 +1,6 @@
 /**
  * @file SpectrumTestSupport.h
  * @brief Lightweight histogram + CSV utilities shared by decay spectrum tests.
- *
- * Header-only, test-only. Models the in-memory pattern used by the existing
- * LinearBreitWheelerBenchmarkCommon.h: linear binning, density normalization
- * via counts / total / binWidth, CSV output with 17-digit precision.
- *
- * The CSV format is consumed by tools/spectrum_plots/plot_spectrum.py.
  */
 
 #ifndef OPALX_UNIT_TESTS_PHYSICS_SPECTRUM_TEST_SUPPORT_H

--- a/unit_tests/Physics/SpectrumTestSupport.h
+++ b/unit_tests/Physics/SpectrumTestSupport.h
@@ -1,0 +1,137 @@
+/**
+ * @file SpectrumTestSupport.h
+ * @brief Lightweight histogram + CSV utilities shared by decay spectrum tests.
+ *
+ * Header-only, test-only. Models the in-memory pattern used by the existing
+ * LinearBreitWheelerBenchmarkCommon.h: linear binning, density normalization
+ * via counts / total / binWidth, CSV output with 17-digit precision.
+ *
+ * The CSV format is consumed by tools/spectrum_plots/plot_spectrum.py.
+ */
+
+#ifndef OPALX_UNIT_TESTS_PHYSICS_SPECTRUM_TEST_SUPPORT_H
+#define OPALX_UNIT_TESTS_PHYSICS_SPECTRUM_TEST_SUPPORT_H
+
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace opalx::test {
+
+    struct Histogram1D {
+        double low                 = 0.0;
+        double high                = 0.0;
+        std::size_t nBins          = 0;
+        std::vector<double> counts;   ///< raw sample counts per bin (out-of-range excluded)
+        std::vector<double> density;  ///< counts / total / binWidth (PDF estimate)
+
+        double binWidth() const { return (high - low) / static_cast<double>(nBins); }
+
+        double center(std::size_t i) const {
+            return low + (static_cast<double>(i) + 0.5) * binWidth();
+        }
+
+        double edgeLow(std::size_t i) const {
+            return low + static_cast<double>(i) * binWidth();
+        }
+
+        double edgeHigh(std::size_t i) const {
+            return low + static_cast<double>(i + 1) * binWidth();
+        }
+    };
+
+    inline Histogram1D makeHistogram(
+            const std::vector<double>& samples, double low, double high, std::size_t nBins) {
+        if (nBins == 0 || !(high > low)) {
+            throw std::invalid_argument("makeHistogram: invalid range or nBins");
+        }
+        Histogram1D h;
+        h.low   = low;
+        h.high  = high;
+        h.nBins = nBins;
+        h.counts.assign(nBins, 0.0);
+        h.density.assign(nBins, 0.0);
+
+        const double width = h.binWidth();
+        double totalIn     = 0.0;
+        for (double s : samples) {
+            if (s < low || s >= high) {
+                continue;
+            }
+            const std::size_t idx =
+                    static_cast<std::size_t>((s - low) / width);
+            if (idx < nBins) {
+                h.counts[idx] += 1.0;
+                totalIn += 1.0;
+            }
+        }
+        if (totalIn > 0.0) {
+            for (std::size_t i = 0; i < nBins; ++i) {
+                h.density[i] = h.counts[i] / (totalIn * width);
+            }
+        }
+        return h;
+    }
+
+    /// L1 distance between sampled density and an analytic PDF on the same binning.
+    /// Both inputs are interpreted as densities; the integrand is |a - b| * binWidth.
+    inline double l1Distance(const Histogram1D& sampled, const std::vector<double>& analyticPdf) {
+        if (sampled.density.size() != analyticPdf.size()) {
+            throw std::invalid_argument("l1Distance: size mismatch");
+        }
+        const double width = sampled.binWidth();
+        double sum         = 0.0;
+        for (std::size_t i = 0; i < sampled.density.size(); ++i) {
+            sum += std::abs(sampled.density[i] - analyticPdf[i]) * width;
+        }
+        return sum;
+    }
+
+    /// Riemann sum of the histogram density (should be ~1 if all samples were in range).
+    inline double histogramArea(const Histogram1D& h) {
+        const double width = h.binWidth();
+        double sum         = 0.0;
+        for (double d : h.density) {
+            sum += d * width;
+        }
+        return sum;
+    }
+
+    inline double sampleMean(const std::vector<double>& samples) {
+        if (samples.empty()) {
+            return 0.0;
+        }
+        double s = 0.0;
+        for (double x : samples) {
+            s += x;
+        }
+        return s / static_cast<double>(samples.size());
+    }
+
+    /// Write a CSV consumable by tools/spectrum_plots/plot_spectrum.py.
+    /// Header: "# x_label: <xLabel>\n# columns: bin_low,bin_high,bin_center,density,count,analytic_pdf\n"
+    inline void writeSpectrumCsv(
+            const std::string& path, const Histogram1D& h,
+            const std::vector<double>& analyticPdf, const std::string& xLabel) {
+        if (analyticPdf.size() != h.nBins) {
+            throw std::invalid_argument("writeSpectrumCsv: analyticPdf size mismatch");
+        }
+        std::ofstream out(path);
+        if (!out) {
+            throw std::runtime_error("writeSpectrumCsv: cannot open " + path);
+        }
+        out.precision(17);
+        out << "# x_label: " << xLabel << "\n";
+        out << "# columns: bin_low,bin_high,bin_center,density,count,analytic_pdf\n";
+        for (std::size_t i = 0; i < h.nBins; ++i) {
+            out << h.edgeLow(i) << ',' << h.edgeHigh(i) << ',' << h.center(i) << ','
+                << h.density[i] << ',' << h.counts[i] << ',' << analyticPdf[i] << '\n';
+        }
+    }
+
+}  // namespace opalx::test
+
+#endif  // OPALX_UNIT_TESTS_PHYSICS_SPECTRUM_TEST_SUPPORT_H

--- a/unit_tests/Physics/SpectrumTestSupport.h
+++ b/unit_tests/Physics/SpectrumTestSupport.h
@@ -16,9 +16,9 @@
 namespace opalx::test {
 
     struct Histogram1D {
-        double low                 = 0.0;
-        double high                = 0.0;
-        std::size_t nBins          = 0;
+        double low        = 0.0;
+        double high       = 0.0;
+        std::size_t nBins = 0;
         std::vector<double> counts;   ///< raw sample counts per bin (out-of-range excluded)
         std::vector<double> density;  ///< counts / total / binWidth (PDF estimate)
 
@@ -28,9 +28,7 @@ namespace opalx::test {
             return low + (static_cast<double>(i) + 0.5) * binWidth();
         }
 
-        double edgeLow(std::size_t i) const {
-            return low + static_cast<double>(i) * binWidth();
-        }
+        double edgeLow(std::size_t i) const { return low + static_cast<double>(i) * binWidth(); }
 
         double edgeHigh(std::size_t i) const {
             return low + static_cast<double>(i + 1) * binWidth();
@@ -55,8 +53,7 @@ namespace opalx::test {
             if (s < low || s >= high) {
                 continue;
             }
-            const std::size_t idx =
-                    static_cast<std::size_t>((s - low) / width);
+            const std::size_t idx = static_cast<std::size_t>((s - low) / width);
             if (idx < nBins) {
                 h.counts[idx] += 1.0;
                 totalIn += 1.0;
@@ -106,10 +103,11 @@ namespace opalx::test {
     }
 
     /// Write a CSV consumable by tools/spectrum_plots/plot_spectrum.py.
-    /// Header: "# x_label: <xLabel>\n# columns: bin_low,bin_high,bin_center,density,count,analytic_pdf\n"
+    /// Header: "# x_label: <xLabel>\n# columns:
+    /// bin_low,bin_high,bin_center,density,count,analytic_pdf\n"
     inline void writeSpectrumCsv(
-            const std::string& path, const Histogram1D& h,
-            const std::vector<double>& analyticPdf, const std::string& xLabel) {
+            const std::string& path, const Histogram1D& h, const std::vector<double>& analyticPdf,
+            const std::string& xLabel) {
         if (analyticPdf.size() != h.nBins) {
             throw std::invalid_argument("writeSpectrumCsv: analyticPdf size mismatch");
         }
@@ -121,8 +119,8 @@ namespace opalx::test {
         out << "# x_label: " << xLabel << "\n";
         out << "# columns: bin_low,bin_high,bin_center,density,count,analytic_pdf\n";
         for (std::size_t i = 0; i < h.nBins; ++i) {
-            out << h.edgeLow(i) << ',' << h.edgeHigh(i) << ',' << h.center(i) << ','
-                << h.density[i] << ',' << h.counts[i] << ',' << analyticPdf[i] << '\n';
+            out << h.edgeLow(i) << ',' << h.edgeHigh(i) << ',' << h.center(i) << ',' << h.density[i]
+                << ',' << h.counts[i] << ',' << analyticPdf[i] << '\n';
         }
     }
 

--- a/unit_tests/Physics/TestMuonDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestMuonDecaySpectrum.cpp
@@ -125,6 +125,11 @@ namespace {
         createParticlesAtRest(muons, nMuons);
 
         Options::seed = 20260515;
+        /** 
+         * Intentionally chosen timestep so all particles decay.
+         * We are testing the daughter particle energy spectrum, not the decay
+         * time.
+         */  
         MuonDecay decay(1.0e-12, 0, Physics::m_mu);
         decay.setDaughterContainer(electrons, Physics::m_e);
 

--- a/unit_tests/Physics/TestMuonDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestMuonDecaySpectrum.cpp
@@ -1,0 +1,178 @@
+/**
+ * @file TestMuonDecaySpectrum.cpp
+ * @brief Distribution-level test of MuonDecay against the analytic Michel spectrum.
+ *
+ * Pulls samples through the full MuonDecay::createDaughterParticles pipeline
+ * (ParticleContainer + Kokkos pool seeded from Options::seed), reads the
+ * daughter electron momenta back to the host, and compares the reduced-energy
+ * histogram against the closed-form Michel PDF
+ *   f(x) = 2 x^2 (3 - 2x) / Z,    Z = (2 x^3 - x^4) evaluated on [x_min, 1].
+ *
+ * Writes muon_michel_spectrum.csv into the test working directory; that CSV
+ * is consumed by tools/spectrum_plots/plot_spectrum.py.
+ */
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include "Ippl.h"
+#include "PartBunch/ParticleContainer.hpp"
+#include "Physics/MuonDecay.h"
+#include "Physics/ParticleProperties.h"
+#include "Physics/Physics.h"
+#include "Processes/GlobalProcesses/MuonDecay.h"
+#include "SpectrumTestSupport.h"
+#include "Utilities/Options.h"
+
+namespace {
+
+    using PC_t = ParticleContainer<double, 3>;
+
+    class MuonDecaySpectrumTest : public ::testing::Test {
+    protected:
+        static void SetUpTestSuite() {
+            int argc    = 0;
+            char** argv = nullptr;
+            ippl::initialize(argc, argv);
+        }
+
+        static void TearDownTestSuite() { ippl::finalize(); }
+
+        void SetUp() override {
+            oldSeed_m                = Options::seed;
+            oldUseQMAttributes_m     = Options::useQMAttributes;
+            Options::useQMAttributes = false;
+        }
+
+        void TearDown() override {
+            Options::seed            = oldSeed_m;
+            Options::useQMAttributes = oldUseQMAttributes_m;
+        }
+
+        std::shared_ptr<PC_t> makeContainer(ParticleType species = ParticleType::UNNAMED) {
+            ippl::Vector<int, 3> nr        = 8;
+            ippl::Vector<double, 3> rmin   = -4.0;
+            ippl::Vector<double, 3> rmax   = 4.0;
+            ippl::Vector<double, 3> origin = rmin;
+            ippl::Vector<double, 3> hr     = (rmax - rmin) / ippl::Vector<double, 3>(nr);
+            std::array<bool, 3> decomp     = {true, true, true};
+
+            ippl::NDIndex<3> domain;
+            for (unsigned i = 0; i < 3; ++i) {
+                domain[i] = ippl::Index(nr[i]);
+            }
+
+            Mesh_t<3> mesh(domain, hr, origin);
+            FieldLayout_t<3> fl(MPI_COMM_WORLD, domain, decomp, true);
+            auto pc = std::make_shared<PC_t>(mesh, fl);
+            pc->Sp  = static_cast<short>(species);
+            pc->setBunchStateHandler(std::make_shared<BunchStateHandler>());
+            return pc;
+        }
+
+        void createParticlesAtRest(std::shared_ptr<PC_t>& pc, std::size_t nPart) {
+            pc->createParticles(nPart);
+            auto R_host = pc->R.getHostMirror();
+            auto P_host = pc->P.getHostMirror();
+            for (std::size_t i = 0; i < nPart; ++i) {
+                R_host(i)[0] = 0.0;
+                R_host(i)[1] = 0.0;
+                R_host(i)[2] = 0.0;
+                P_host(i)[0] = 0.0;
+                P_host(i)[1] = 0.0;
+                P_host(i)[2] = 0.0;
+            }
+            Kokkos::deep_copy(pc->R.getView(), R_host);
+            Kokkos::deep_copy(pc->P.getView(), P_host);
+            Kokkos::fence();
+        }
+
+    private:
+        int oldSeed_m             = -1;
+        bool oldUseQMAttributes_m = false;
+    };
+
+    /// Closed-form normalization of the Michel spectrum on [a, 1]:
+    ///   Z(a) = integral_a^1 2 x^2 (3 - 2 x) dx = (2 x^3 - x^4)|_a^1 = 1 - 2 a^3 + a^4.
+    double michelNormalization(double a) {
+        return 1.0 - 2.0 * a * a * a + a * a * a * a;
+    }
+
+    /// Closed-form mean of the Michel spectrum on [a, 1]:
+    ///   E[x] = integral_a^1 x f(x) dx / Z = ((6/4) x^4 - (4/5) x^5)|_a^1 / Z
+    double michelMean(double a) {
+        const double a4   = a * a * a * a;
+        const double a5   = a4 * a;
+        const double num  = (1.5 - 0.8) - (1.5 * a4 - 0.8 * a5);
+        return num / michelNormalization(a);
+    }
+
+    TEST_F(MuonDecaySpectrumTest, MuonDecaySpectrumMatchesMichel) {
+        constexpr std::size_t nMuons = 100000;
+        constexpr std::size_t nBins  = 50;
+
+        auto muons     = makeContainer();
+        auto electrons = makeContainer(ParticleType::ELECTRON);
+        muons->setM(Physics::m_mu);
+        electrons->setM(Physics::m_e);
+        createParticlesAtRest(muons, nMuons);
+
+        Options::seed = 20260515;
+        MuonDecay decay(1.0e-12, 0, Physics::m_mu);
+        decay.setDaughterContainer(electrons, Physics::m_e);
+
+        const std::size_t marked    = decay.apply(*muons, 1.0, 0, 0);
+        const std::size_t destroyed = muons->deleteInvalidParticles();
+        ASSERT_EQ(marked, nMuons);
+        ASSERT_EQ(destroyed, nMuons);
+        ASSERT_EQ(electrons->getLocalNum(), nMuons);
+
+        auto eP_host = electrons->P.getHostMirror();
+        Kokkos::deep_copy(eP_host, electrons->P.getView());
+
+        const double eMax = Physics::MuonDecay::maxElectronEnergy();  // m_mu / 2
+        const double xMin = Physics::MuonDecay::minElectronX();
+
+        std::vector<double> xSamples;
+        xSamples.reserve(nMuons);
+        for (std::size_t i = 0; i < nMuons; ++i) {
+            const double bg2 = eP_host(i)[0] * eP_host(i)[0] + eP_host(i)[1] * eP_host(i)[1]
+                               + eP_host(i)[2] * eP_host(i)[2];
+            const double energy = std::sqrt(1.0 + bg2) * Physics::m_e;
+            xSamples.push_back(energy / eMax);
+        }
+
+        const auto hist = opalx::test::makeHistogram(xSamples, xMin, 1.0, nBins);
+
+        const double Z = michelNormalization(xMin);
+        std::vector<double> analyticPdf(nBins, 0.0);
+        for (std::size_t i = 0; i < nBins; ++i) {
+            const double x  = hist.center(i);
+            analyticPdf[i] = Physics::MuonDecay::michelSpectrum(x) / Z;
+        }
+
+        const double l1       = opalx::test::l1Distance(hist, analyticPdf);
+        const double meanX    = opalx::test::sampleMean(xSamples);
+        const double area     = opalx::test::histogramArea(hist);
+        const double meanRef  = michelMean(xMin);
+
+        std::cout << "[MuonDecaySpectrum] L1=" << l1 << " mean=" << meanX
+                  << " (analytic=" << meanRef << ") area=" << area << '\n';
+
+        EXPECT_LT(l1, 0.10);
+        EXPECT_NEAR(meanX, meanRef, meanRef * 0.02);
+        EXPECT_NEAR(area, 1.0, 0.01);
+
+        const std::string csvPath = "muon_michel_spectrum.csv";
+        opalx::test::writeSpectrumCsv(csvPath, hist, analyticPdf, "x = E_e / (m_mu/2)");
+        std::cout << "[MuonDecaySpectrum] CSV written: " << csvPath << '\n';
+    }
+
+}  // namespace

--- a/unit_tests/Physics/TestMuonDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestMuonDecaySpectrum.cpp
@@ -101,16 +101,14 @@ namespace {
 
     /// Closed-form normalization of the Michel spectrum on [a, 1]:
     ///   Z(a) = integral_a^1 2 x^2 (3 - 2 x) dx = (2 x^3 - x^4)|_a^1 = 1 - 2 a^3 + a^4.
-    double michelNormalization(double a) {
-        return 1.0 - 2.0 * a * a * a + a * a * a * a;
-    }
+    double michelNormalization(double a) { return 1.0 - 2.0 * a * a * a + a * a * a * a; }
 
     /// Closed-form mean of the Michel spectrum on [a, 1]:
     ///   E[x] = integral_a^1 x f(x) dx / Z = ((6/4) x^4 - (4/5) x^5)|_a^1 / Z
     double michelMean(double a) {
-        const double a4   = a * a * a * a;
-        const double a5   = a4 * a;
-        const double num  = (1.5 - 0.8) - (1.5 * a4 - 0.8 * a5);
+        const double a4  = a * a * a * a;
+        const double a5  = a4 * a;
+        const double num = (1.5 - 0.8) - (1.5 * a4 - 0.8 * a5);
         return num / michelNormalization(a);
     }
 
@@ -125,11 +123,11 @@ namespace {
         createParticlesAtRest(muons, nMuons);
 
         Options::seed = 20260515;
-        /** 
+        /**
          * Intentionally chosen timestep so all particles decay.
          * We are testing the daughter particle energy spectrum, not the decay
          * time.
-         */  
+         */
         MuonDecay decay(1.0e-12, 0, Physics::m_mu);
         decay.setDaughterContainer(electrons, Physics::m_e);
 
@@ -159,14 +157,14 @@ namespace {
         const double Z = michelNormalization(xMin);
         std::vector<double> analyticPdf(nBins, 0.0);
         for (std::size_t i = 0; i < nBins; ++i) {
-            const double x  = hist.center(i);
+            const double x = hist.center(i);
             analyticPdf[i] = Physics::MuonDecay::michelSpectrum(x) / Z;
         }
 
-        const double l1       = opalx::test::l1Distance(hist, analyticPdf);
-        const double meanX    = opalx::test::sampleMean(xSamples);
-        const double area     = opalx::test::histogramArea(hist);
-        const double meanRef  = michelMean(xMin);
+        const double l1      = opalx::test::l1Distance(hist, analyticPdf);
+        const double meanX   = opalx::test::sampleMean(xSamples);
+        const double area    = opalx::test::histogramArea(hist);
+        const double meanRef = michelMean(xMin);
 
         std::cout << "[MuonDecaySpectrum] L1=" << l1 << " mean=" << meanX
                   << " (analytic=" << meanRef << ") area=" << area << '\n';

--- a/unit_tests/Physics/TestPionDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestPionDecaySpectrum.cpp
@@ -179,6 +179,11 @@ namespace {
         createParticles(pions, nPions, parentBetaGam);
 
         Options::seed = 20260517;
+        /** 
+         * Intentionally chosen timestep so all particles decay.
+         * We are testing the daughter particle energy spectrum, not the decay
+         * time.
+         */  
         PionDecay decay(1.0e-12, 0, Physics::m_pi);
         decay.setDaughterContainer(muons, Physics::m_mu);
 

--- a/unit_tests/Physics/TestPionDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestPionDecaySpectrum.cpp
@@ -1,0 +1,235 @@
+/**
+ * @file TestPionDecaySpectrum.cpp
+ * @brief Distribution-level tests of PionDecay (deterministic two-body kinematics).
+ *
+ * Drives PionDecay::createDaughterParticles through the full ParticleContainer
+ * + Kokkos pool pipeline. Two checks:
+ *
+ *  1. PionDecayRestFrameMomentumIsFixed:
+ *     With pions at rest, every daughter muon must have |p| = (M_pi^2 - m_mu^2) / (2 M_pi),
+ *     and the cos(theta) distribution of the decay direction must be uniform on [-1, 1].
+ *
+ *  2. PionDecayBoostedLabEnergyIsFlatBox:
+ *     With boosted pions (pz = 5 in beta*gamma units), the lab-frame muon energy
+ *     spectrum is uniform on [E_-, E_+] where
+ *        E_+- = gamma * E* +- beta*gamma * p*,
+ *        E*   = (M_pi^2 + m_mu^2) / (2 M_pi),
+ *        p*   = (M_pi^2 - m_mu^2) / (2 M_pi).
+ *
+ * CSVs (consumed by tools/spectrum_plots/plot_spectrum.py):
+ *   - pion_rest_costheta.csv
+ *   - pion_boosted_energy_box.csv
+ */
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include "Ippl.h"
+#include "PartBunch/ParticleContainer.hpp"
+#include "Physics/ParticleProperties.h"
+#include "Physics/Physics.h"
+#include "Processes/GlobalProcesses/PionDecay.h"
+#include "SpectrumTestSupport.h"
+#include "Utilities/Options.h"
+
+namespace {
+
+    using PC_t = ParticleContainer<double, 3>;
+
+    class PionDecaySpectrumTest : public ::testing::Test {
+    protected:
+        static void SetUpTestSuite() {
+            int argc    = 0;
+            char** argv = nullptr;
+            ippl::initialize(argc, argv);
+        }
+
+        static void TearDownTestSuite() { ippl::finalize(); }
+
+        void SetUp() override {
+            oldSeed_m                = Options::seed;
+            oldUseQMAttributes_m     = Options::useQMAttributes;
+            Options::useQMAttributes = false;
+        }
+
+        void TearDown() override {
+            Options::seed            = oldSeed_m;
+            Options::useQMAttributes = oldUseQMAttributes_m;
+        }
+
+        std::shared_ptr<PC_t> makeContainer(ParticleType species = ParticleType::UNNAMED) {
+            ippl::Vector<int, 3> nr        = 8;
+            ippl::Vector<double, 3> rmin   = -4.0;
+            ippl::Vector<double, 3> rmax   = 4.0;
+            ippl::Vector<double, 3> origin = rmin;
+            ippl::Vector<double, 3> hr     = (rmax - rmin) / ippl::Vector<double, 3>(nr);
+            std::array<bool, 3> decomp     = {true, true, true};
+
+            ippl::NDIndex<3> domain;
+            for (unsigned i = 0; i < 3; ++i) {
+                domain[i] = ippl::Index(nr[i]);
+            }
+
+            Mesh_t<3> mesh(domain, hr, origin);
+            FieldLayout_t<3> fl(MPI_COMM_WORLD, domain, decomp, true);
+            auto pc = std::make_shared<PC_t>(mesh, fl);
+            pc->Sp  = static_cast<short>(species);
+            pc->setBunchStateHandler(std::make_shared<BunchStateHandler>());
+            return pc;
+        }
+
+        void createParticles(std::shared_ptr<PC_t>& pc, std::size_t nPart, double pz) {
+            pc->createParticles(nPart);
+            auto R_host = pc->R.getHostMirror();
+            auto P_host = pc->P.getHostMirror();
+            for (std::size_t i = 0; i < nPart; ++i) {
+                R_host(i)[0] = 0.0;
+                R_host(i)[1] = 0.0;
+                R_host(i)[2] = 0.0;
+                P_host(i)[0] = 0.0;
+                P_host(i)[1] = 0.0;
+                P_host(i)[2] = pz;
+            }
+            Kokkos::deep_copy(pc->R.getView(), R_host);
+            Kokkos::deep_copy(pc->P.getView(), P_host);
+            Kokkos::fence();
+        }
+
+    private:
+        int oldSeed_m             = -1;
+        bool oldUseQMAttributes_m = false;
+    };
+
+    TEST_F(PionDecaySpectrumTest, PionDecayRestFrameMomentumIsFixed) {
+        constexpr std::size_t nPions = 100000;
+        constexpr std::size_t nBins  = 50;
+
+        auto pions = makeContainer();
+        auto muons = makeContainer(ParticleType::MUON);
+        pions->setM(Physics::m_pi);
+        muons->setM(Physics::m_mu);
+        createParticles(pions, nPions, 0.0);
+
+        Options::seed = 20260516;
+        PionDecay decay(1.0e-12, 0, Physics::m_pi);
+        decay.setDaughterContainer(muons, Physics::m_mu);
+
+        const std::size_t marked    = decay.apply(*pions, 1.0, 0, 0);
+        const std::size_t destroyed = pions->deleteInvalidParticles();
+        ASSERT_EQ(marked, nPions);
+        ASSERT_EQ(destroyed, nPions);
+        ASSERT_EQ(muons->getLocalNum(), nPions);
+
+        auto muP_host = muons->P.getHostMirror();
+        Kokkos::deep_copy(muP_host, muons->P.getView());
+
+        const double pFixed = (Physics::m_pi * Physics::m_pi - Physics::m_mu * Physics::m_mu)
+                              / (2.0 * Physics::m_pi);
+
+        std::vector<double> cosThetaSamples;
+        cosThetaSamples.reserve(nPions);
+        double maxRelDev = 0.0;
+        for (std::size_t i = 0; i < nPions; ++i) {
+            const double bgx = muP_host(i)[0];
+            const double bgy = muP_host(i)[1];
+            const double bgz = muP_host(i)[2];
+            const double pmag =
+                    Physics::m_mu * std::sqrt(bgx * bgx + bgy * bgy + bgz * bgz);
+            maxRelDev = std::max(maxRelDev, std::abs(pmag - pFixed) / pFixed);
+            cosThetaSamples.push_back(Physics::m_mu * bgz / pmag);
+        }
+        std::cout << "[PionDecayRestFrame] |p|=" << pFixed
+                  << " max rel dev=" << maxRelDev << '\n';
+        EXPECT_LT(maxRelDev, 1.0e-12);
+
+        const auto hist = opalx::test::makeHistogram(cosThetaSamples, -1.0, 1.0, nBins);
+        const std::vector<double> uniform(nBins, 0.5);
+
+        const double l1   = opalx::test::l1Distance(hist, uniform);
+        const double mean = opalx::test::sampleMean(cosThetaSamples);
+        const double area = opalx::test::histogramArea(hist);
+        std::cout << "[PionDecayRestFrame] cos(theta) L1=" << l1 << " mean=" << mean
+                  << " area=" << area << '\n';
+
+        EXPECT_LT(l1, 0.10);
+        EXPECT_NEAR(mean, 0.0, 0.02);
+        EXPECT_NEAR(area, 1.0, 0.01);
+
+        const std::string csvPath = "pion_rest_costheta.csv";
+        opalx::test::writeSpectrumCsv(csvPath, hist, uniform, "cos(theta) (rest frame)");
+        std::cout << "[PionDecayRestFrame] CSV written: " << csvPath << '\n';
+    }
+
+    TEST_F(PionDecaySpectrumTest, PionDecayBoostedLabEnergyIsFlatBox) {
+        constexpr std::size_t nPions   = 100000;
+        constexpr std::size_t nBins    = 50;
+        constexpr double parentBetaGam = 5.0;  // pz of pion in beta*gamma units
+
+        auto pions = makeContainer();
+        auto muons = makeContainer(ParticleType::MUON);
+        pions->setM(Physics::m_pi);
+        muons->setM(Physics::m_mu);
+        createParticles(pions, nPions, parentBetaGam);
+
+        Options::seed = 20260517;
+        PionDecay decay(1.0e-12, 0, Physics::m_pi);
+        decay.setDaughterContainer(muons, Physics::m_mu);
+
+        const std::size_t marked    = decay.apply(*pions, 1.0, 0, 0);
+        const std::size_t destroyed = pions->deleteInvalidParticles();
+        ASSERT_EQ(marked, nPions);
+        ASSERT_EQ(destroyed, nPions);
+        ASSERT_EQ(muons->getLocalNum(), nPions);
+
+        auto muP_host = muons->P.getHostMirror();
+        Kokkos::deep_copy(muP_host, muons->P.getView());
+
+        // Rest-frame two-body kinematics.
+        const double M     = Physics::m_pi;
+        const double md    = Physics::m_mu;
+        const double pStar = (M * M - md * md) / (2.0 * M);
+        const double eStar = (M * M + md * md) / (2.0 * M);
+
+        // Parent boost.
+        const double gamma   = std::sqrt(1.0 + parentBetaGam * parentBetaGam);
+        const double betaGam = parentBetaGam;  // = beta * gamma
+        const double eMinus  = gamma * eStar - betaGam * pStar;
+        const double ePlus   = gamma * eStar + betaGam * pStar;
+        const double uniform = 1.0 / (ePlus - eMinus);
+
+        std::vector<double> labEnergies;
+        labEnergies.reserve(nPions);
+        for (std::size_t i = 0; i < nPions; ++i) {
+            const double bg2 = muP_host(i)[0] * muP_host(i)[0] + muP_host(i)[1] * muP_host(i)[1]
+                               + muP_host(i)[2] * muP_host(i)[2];
+            labEnergies.push_back(std::sqrt(1.0 + bg2) * Physics::m_mu);
+        }
+
+        const auto hist = opalx::test::makeHistogram(labEnergies, eMinus, ePlus, nBins);
+        const std::vector<double> analyticPdf(nBins, uniform);
+
+        const double l1      = opalx::test::l1Distance(hist, analyticPdf);
+        const double mean    = opalx::test::sampleMean(labEnergies);
+        const double meanRef = 0.5 * (eMinus + ePlus);
+        const double area    = opalx::test::histogramArea(hist);
+        std::cout << "[PionDecayBoosted] E in [" << eMinus << ", " << ePlus
+                  << "] GeV, L1=" << l1 << " mean=" << mean
+                  << " (analytic=" << meanRef << ") area=" << area << '\n';
+
+        EXPECT_LT(l1, 0.10);
+        EXPECT_NEAR(mean, meanRef, 0.005 * (ePlus - eMinus));
+        EXPECT_NEAR(area, 1.0, 0.01);
+
+        const std::string csvPath = "pion_boosted_energy_box.csv";
+        opalx::test::writeSpectrumCsv(csvPath, hist, analyticPdf, "E_mu^lab [GeV]");
+        std::cout << "[PionDecayBoosted] CSV written: " << csvPath << '\n';
+    }
+
+}  // namespace

--- a/unit_tests/Physics/TestPionDecaySpectrum.cpp
+++ b/unit_tests/Physics/TestPionDecaySpectrum.cpp
@@ -137,16 +137,14 @@ namespace {
         cosThetaSamples.reserve(nPions);
         double maxRelDev = 0.0;
         for (std::size_t i = 0; i < nPions; ++i) {
-            const double bgx = muP_host(i)[0];
-            const double bgy = muP_host(i)[1];
-            const double bgz = muP_host(i)[2];
-            const double pmag =
-                    Physics::m_mu * std::sqrt(bgx * bgx + bgy * bgy + bgz * bgz);
-            maxRelDev = std::max(maxRelDev, std::abs(pmag - pFixed) / pFixed);
+            const double bgx  = muP_host(i)[0];
+            const double bgy  = muP_host(i)[1];
+            const double bgz  = muP_host(i)[2];
+            const double pmag = Physics::m_mu * std::sqrt(bgx * bgx + bgy * bgy + bgz * bgz);
+            maxRelDev         = std::max(maxRelDev, std::abs(pmag - pFixed) / pFixed);
             cosThetaSamples.push_back(Physics::m_mu * bgz / pmag);
         }
-        std::cout << "[PionDecayRestFrame] |p|=" << pFixed
-                  << " max rel dev=" << maxRelDev << '\n';
+        std::cout << "[PionDecayRestFrame] |p|=" << pFixed << " max rel dev=" << maxRelDev << '\n';
         EXPECT_LT(maxRelDev, 1.0e-12);
 
         const auto hist = opalx::test::makeHistogram(cosThetaSamples, -1.0, 1.0, nBins);
@@ -179,11 +177,11 @@ namespace {
         createParticles(pions, nPions, parentBetaGam);
 
         Options::seed = 20260517;
-        /** 
+        /**
          * Intentionally chosen timestep so all particles decay.
          * We are testing the daughter particle energy spectrum, not the decay
          * time.
-         */  
+         */
         PionDecay decay(1.0e-12, 0, Physics::m_pi);
         decay.setDaughterContainer(muons, Physics::m_mu);
 
@@ -224,9 +222,8 @@ namespace {
         const double mean    = opalx::test::sampleMean(labEnergies);
         const double meanRef = 0.5 * (eMinus + ePlus);
         const double area    = opalx::test::histogramArea(hist);
-        std::cout << "[PionDecayBoosted] E in [" << eMinus << ", " << ePlus
-                  << "] GeV, L1=" << l1 << " mean=" << mean
-                  << " (analytic=" << meanRef << ") area=" << area << '\n';
+        std::cout << "[PionDecayBoosted] E in [" << eMinus << ", " << ePlus << "] GeV, L1=" << l1
+                  << " mean=" << mean << " (analytic=" << meanRef << ") area=" << area << '\n';
 
         EXPECT_LT(l1, 0.10);
         EXPECT_NEAR(mean, meanRef, 0.005 * (ePlus - eMinus));


### PR DESCRIPTION
## Summary
- Add two distribution-level unit tests that drive `MuonDecay` and `PionDecay` through the full `ParticleContainer` + Kokkos pool pipeline and compare sampled histograms against closed-form analytic PDFs.
- Tests use **L1 distance + relative mean error** as the comparison metric (1e5 samples each, runtime <1 s total) and emit CSVs for offline plotting.
- Add `tools/spectrum_plots/plot_spectrum.py` to render the CSVs as PNG histograms with the analytic curve overlaid.

## What's tested

**`TestMuonDecaySpectrum.cpp`** (1 test)
- Michel spectrum of the daughter electron's reduced energy `x = E_e / (m_μ/2)` from `μ⁻ → e⁻ + ν̄_e + ν_μ` at rest, compared to `f(x) = 2x²(3 − 2x) / Z` analytically normalized on `[m_e/(m_μ/2), 1]`.

**`TestPionDecaySpectrum.cpp`** (2 tests)
- `PionDecayRestFrameMomentumIsFixed`: every daughter muon has `|p| = (M_π² − m_μ²)/(2 M_π)` (verified at machine precision, max rel deviation ~3.5e-16), and rest-frame `cos θ` is uniform on `[−1, 1]`.
- `PionDecayBoostedLabEnergyIsFlatBox`: with parents at `βγ_z = 5`, the lab muon-energy spectrum is the classic uniform box on `[γE* − βγ p*, γE* + βγ p*]`.

## Files added
- `unit_tests/Physics/SpectrumTestSupport.h` 
- `unit_tests/Physics/TestMuonDecaySpectrum.cpp`
- `unit_tests/Physics/TestPionDecaySpectrum.cpp`
- `tools/spectrum_plots/plot_spectrum.py` - generate plots of the histograms
- `unit_tests/Physics/CMakeLists.txt` 

## Runtime
### Mac M4 Serial
```
24/71 Test #24: TestMuonDecaySpectrum ..............   Passed    0.93 sec
25/71 Test #25: TestPionDecaySpectrum ..............   Passed    0.38 sec
```
### Daint GH
```
24/71 Test #24: TestMuonDecaySpectrum ..............   Passed    1.44 sec
25/71 Test #25: TestPionDecaySpectrum ..............   Passed    1.10 sec
```