### PR TITLE
Write Spin Polarisation to `.stat` and `.h5` output

### DIFF
--- a/src/AbsBeamline/Monitor.cpp
+++ b/src/AbsBeamline/Monitor.cpp
@@ -131,8 +131,7 @@ bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
                 const Vector_t<double, 3> pol(
                         static_cast<double>(hPol(i)[0]), static_cast<double>(hPol(i)[1]),
                         static_cast<double>(hPol(i)[2]));
-                lossDs_m->addParticle(
-                        OpalParticle(id, crossingR, P, crossingTime, q, m, pol));
+                lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m, pol));
             } else {
                 lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m));
             }

--- a/src/AbsBeamline/Monitor.cpp
+++ b/src/AbsBeamline/Monitor.cpp
@@ -93,6 +93,14 @@ bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     auto hQ  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Qview);
     auto hM  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Mview);
 
+    const bool hasSpin = pc->hasSpin();
+    using SpinHostView = Kokkos::View<ippl::Vector<float, 3>*, Kokkos::HostSpace>;
+    SpinHostView hPol;
+    if (hasSpin) {
+        auto Polview = pc->Pol.getView();
+        hPol         = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Polview);
+    }
+
     const bool qmAreAttributes =
             (pc->getQMStorageMode() == ParticleContainer_t::QMStorageMode::Attributes);
 
@@ -119,7 +127,15 @@ bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
             const double q       = qmAreAttributes ? hQ(i) : hQ(0);
             const double m       = qmAreAttributes ? hM(i) : hM(0);
 
-            lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m));
+            if (hasSpin) {
+                const Vector_t<double, 3> pol(
+                        static_cast<double>(hPol(i)[0]), static_cast<double>(hPol(i)[1]),
+                        static_cast<double>(hPol(i)[2]));
+                lossDs_m->addParticle(
+                        OpalParticle(id, crossingR, P, crossingTime, q, m, pol));
+            } else {
+                lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m));
+            }
         }
     }
 
@@ -170,7 +186,16 @@ bool Monitor::apply(
         const double q       = qmAreAttributes ? Qview(i) : Qview(0);
         const double m       = qmAreAttributes ? Mview(i) : Mview(0);
 
-        lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m));
+        if (pc->hasSpin()) {
+            auto Polview      = pc->Pol.getView();
+            const auto polRaw = Polview(i);
+            const Vector_t<double, 3> pol(
+                    static_cast<double>(polRaw[0]), static_cast<double>(polRaw[1]),
+                    static_cast<double>(polRaw[2]));
+            lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m, pol));
+        } else {
+            lossDs_m->addParticle(OpalParticle(id, crossingR, P, crossingTime, q, m));
+        }
     }
 
     return false;
@@ -225,6 +250,14 @@ void Monitor::driftToCorrectPositionAndSave(
     auto hQ  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Qview);
     auto hM  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Mview);
 
+    const bool hasSpin = pc->hasSpin();
+    using SpinHostView = Kokkos::View<ippl::Vector<float, 3>*, Kokkos::HostSpace>;
+    SpinHostView hPol;
+    if (hasSpin) {
+        auto Polview = pc->Pol.getView();
+        hPol         = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Polview);
+    }
+
     const auto nLoc = pc->getLocalNum();
 
     const bool qmAreAttributes =
@@ -252,7 +285,14 @@ void Monitor::driftToCorrectPositionAndSave(
         const double m = macroWeight > 0.0 ? macroMassGeV * Units::GeV2MeV / macroWeight
                                            : macroMassGeV * Units::GeV2MeV;
 
-        lossDs_m->addParticle(OpalParticle(id, localR, globalP, particleTime, q, m));
+        if (hasSpin) {
+            const Vector_t<double, 3> pol(
+                    static_cast<double>(hPol(i)[0]), static_cast<double>(hPol(i)[1]),
+                    static_cast<double>(hPol(i)[2]));
+            lossDs_m->addParticle(OpalParticle(id, localR, globalP, particleTime, q, m, pol));
+        } else {
+            lossDs_m->addParticle(OpalParticle(id, localR, globalP, particleTime, q, m));
+        }
     }
 }
 

--- a/src/AbstractObjects/OpalParticle.cpp
+++ b/src/AbstractObjects/OpalParticle.cpp
@@ -28,3 +28,8 @@ OpalParticle::OpalParticle(
         int64_t id, Vector_t<double, 3> const& R, Vector_t<double, 3> const& P, double t, double q,
         double m)
     : id_m(id), R_m(R), P_m(P), time_m(t), charge_m(q), mass_m(m) {}
+
+OpalParticle::OpalParticle(
+        int64_t id, Vector_t<double, 3> const& R, Vector_t<double, 3> const& P, double t, double q,
+        double m, Vector_t<double, 3> const& Pol)
+    : id_m(id), R_m(R), P_m(P), time_m(t), charge_m(q), mass_m(m), Pol_m(Pol), hasPol_m(true) {}

--- a/src/AbstractObjects/OpalParticle.h
+++ b/src/AbstractObjects/OpalParticle.h
@@ -40,6 +40,12 @@ public:
             int64_t id, Vector_t<double, 3> const& R, Vector_t<double, 3> const& P, double time,
             double q, double m);
 
+    /// Constructor including the per-particle polarization vector.
+    /// Sets the hasPol flag so the loss sink emits the polx/poly/polz columns.
+    OpalParticle(
+            int64_t id, Vector_t<double, 3> const& R, Vector_t<double, 3> const& P, double time,
+            double q, double m, Vector_t<double, 3> const& Pol);
+
     OpalParticle();
 
     /// Set the horizontal position in m.
@@ -109,6 +115,16 @@ public:
     /// Get mass in GeV/c^2
     double getMass() const;
 
+    /// Whether a polarization vector was attached to this particle.
+    bool hasPol() const;
+
+    /// Get the rest-frame polarization vector (rest-frame components along lab axes).
+    /// Only meaningful when hasPol() is true.
+    const Vector_t<double, 3>& getPol() const;
+
+    /// Attach a polarization vector to this particle.
+    void setPol(Vector_t<double, 3> const&);
+
 private:
     int64_t id_m;
     Vector_t<double, 3> R_m;
@@ -116,6 +132,8 @@ private:
     double time_m;
     double charge_m;
     double mass_m;
+    Vector_t<double, 3> Pol_m{0.0, 0.0, 0.0};
+    bool hasPol_m = false;
 };
 
 inline void OpalParticle::setX(double val) { R_m[X] = val; }
@@ -164,5 +182,14 @@ inline double OpalParticle::getTime() const { return time_m; }
 inline double OpalParticle::getCharge() const { return charge_m; }
 
 inline double OpalParticle::getMass() const { return mass_m; }
+
+inline bool OpalParticle::hasPol() const { return hasPol_m; }
+
+inline const Vector_t<double, 3>& OpalParticle::getPol() const { return Pol_m; }
+
+inline void OpalParticle::setPol(Vector_t<double, 3> const& Pol) {
+    Pol_m    = Pol;
+    hasPol_m = true;
+}
 
 #endif  // OPALX_OpalParticle_HH

--- a/src/Algorithms/DistributionMoments.cpp
+++ b/src/Algorithms/DistributionMoments.cpp
@@ -297,6 +297,46 @@ void DistributionMoments::computeMinMaxPosition(
 }
 
 // ---------------------------------------------------------------------------
+// computePolarizationMoments -- per-component mean + RMS of the spin vector
+// ---------------------------------------------------------------------------
+void DistributionMoments::computePolarizationMoments(
+        ippl::ParticleAttrib<ippl::Vector<float, 3>>::view_type Polview, size_t Np, size_t Nlocal) {
+    // Pol is stored as float to save memory; reduce in double and cast on read.
+    // Np is the global particle count (>= 1, guarded by the caller); it normalizes
+    // both sums and sums-of-squares so the result matches R/P moment conventions.
+    Np = (Np == 0) ? 1 : Np;
+
+    // Reduce 6 quantities: [0..2] sums (x, y, z), [3..5] sums-of-squares.
+    SumArray<6> loc;
+    Kokkos::parallel_reduce(
+            "computePolarizationMoments", Nlocal,
+            KOKKOS_LAMBDA(const size_t k, SumArray<6>& upd) {
+                const double px = static_cast<double>(Polview(k)[0]);
+                const double py = static_cast<double>(Polview(k)[1]);
+                const double pz = static_cast<double>(Polview(k)[2]);
+                upd.data[0] += px;
+                upd.data[1] += py;
+                upd.data[2] += pz;
+                upd.data[3] += px * px;
+                upd.data[4] += py * py;
+                upd.data[5] += pz * pz;
+            },
+            Kokkos::Sum<SumArray<6>>(loc));
+    Kokkos::fence();
+
+    double glob[6];
+    ippl::Comm->allreduce(&loc.data[0], &glob[0], 6, std::plus<double>());
+
+    for (size_t i = 0; i < Dim; ++i) {
+        const double mean  = glob[i] / Np;
+        const double mean2 = glob[i + Dim] / Np;
+        const double var   = mean2 - mean * mean;
+        meanPol_m(i)       = mean;
+        stdPol_m(i)        = var > 0.0 ? std::sqrt(var) : 0.0;
+    }
+}
+
+// ---------------------------------------------------------------------------
 
 void DistributionMoments::compute(
         const std::vector<OpalParticle>::const_iterator& /*first*/,
@@ -609,6 +649,8 @@ void DistributionMoments::reset() {
     meanP_m         = 0.0;
     stdR_m          = 0.0;
     stdP_m          = 0.0;
+    meanPol_m       = 0.0;
+    stdPol_m        = 0.0;
     stdRP_m         = 0.0;
     normalizedEps_m = 0.0;
     geometricEps_m  = 0.0;

--- a/src/Algorithms/DistributionMoments.h
+++ b/src/Algorithms/DistributionMoments.h
@@ -212,9 +212,7 @@ inline Vector_t<double, 3> DistributionMoments::getStandardDeviationMomentum() c
     return stdP_m;
 }
 
-inline Vector_t<double, 3> DistributionMoments::getMeanPolarization() const {
-    return meanPol_m;
-}
+inline Vector_t<double, 3> DistributionMoments::getMeanPolarization() const { return meanPol_m; }
 
 inline Vector_t<double, 3> DistributionMoments::getStandardDeviationPolarization() const {
     return stdPol_m;

--- a/src/Algorithms/DistributionMoments.h
+++ b/src/Algorithms/DistributionMoments.h
@@ -68,6 +68,9 @@ public:
             ippl::ParticleAttrib<double>::view_type Mview, size_t Np, size_t Nlocal);
     void computeMinMaxPosition(
             ippl::ParticleAttrib<Vector_t<double, 3>>::view_type Rview, size_t Nlcoal);
+    void computePolarizationMoments(
+            ippl::ParticleAttrib<ippl::Vector<float, 3>>::view_type Polview, size_t Np,
+            size_t Nlocal);
     void computeMeanKineticEnergy();
     void computeDebyeLength(
             ippl::ParticleAttrib<Vector_t<double, 3>>::view_type Pview, size_t Np, size_t Nlocal,
@@ -78,6 +81,8 @@ public:
     Vector_t<double, 3> getStandardDeviationPosition() const;
     Vector_t<double, 3> getMeanMomentum() const;
     Vector_t<double, 3> getStandardDeviationMomentum() const;
+    Vector_t<double, 3> getMeanPolarization() const;
+    Vector_t<double, 3> getStandardDeviationPolarization() const;
     Vector_t<double, 3> getNormalizedEmittance() const;
     Vector_t<double, 3> getGeometricEmittance() const;
     Vector_t<double, 3> getStandardDeviationRP() const;
@@ -149,6 +154,8 @@ private:
     Vector_t<double, 3> meanP_m;
     Vector_t<double, 3> stdR_m;
     Vector_t<double, 3> stdP_m;
+    Vector_t<double, 3> meanPol_m;
+    Vector_t<double, 3> stdPol_m;
     Vector_t<double, 3> stdRP_m;
     Vector_t<double, 3> normalizedEps_m;
     Vector_t<double, 3> geometricEps_m;
@@ -203,6 +210,14 @@ inline Vector_t<double, 3> DistributionMoments::getMeanMomentum() const { return
 
 inline Vector_t<double, 3> DistributionMoments::getStandardDeviationMomentum() const {
     return stdP_m;
+}
+
+inline Vector_t<double, 3> DistributionMoments::getMeanPolarization() const {
+    return meanPol_m;
+}
+
+inline Vector_t<double, 3> DistributionMoments::getStandardDeviationPolarization() const {
+    return stdPol_m;
 }
 
 inline Vector_t<double, 3> DistributionMoments::getNormalizedEmittance() const {

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -243,6 +243,10 @@ public:
         size_t Nlocal = this->getLocalNum();
 
         distMoments_m.computeMoments(this->R.getView(), this->P.getView(), getMView(), Np, Nlocal);
+
+        if (spinEnabled_m) {
+            distMoments_m.computePolarizationMoments(Pol.getView(), Np, Nlocal);
+        }
     }
 
     void setEnergyReferenceMass(double referenceMassGeV, bool rescaleToReference = true) {
@@ -260,76 +264,15 @@ public:
     Vector_t<double, 3> getRmsRP() const { return distMoments_m.getStandardDeviationRP(); }
 
     /// Mean polarization vector across the bunch: $\langle \vec P \rangle$.
-    /// Returns the zero vector when the container does not track spin.
-    Vector_t<double, 3> getMeanPol() const {
-        Vector_t<double, 3> mean(0.0);
-        if (!spinEnabled_m) {
-            return mean;
-        }
-        const size_t nLocal = this->getLocalNum();
-        auto Polview        = Pol.getView();
-        double sx = 0.0, sy = 0.0, sz = 0.0;
-        Kokkos::parallel_reduce(
-                "ParticleContainer::getMeanPol", nLocal,
-                KOKKOS_LAMBDA(const size_t i, double& lsx, double& lsy, double& lsz) {
-                    lsx += static_cast<double>(Polview(i)[0]);
-                    lsy += static_cast<double>(Polview(i)[1]);
-                    lsz += static_cast<double>(Polview(i)[2]);
-                },
-                sx, sy, sz);
-        Kokkos::fence();
-        double localSum[3]  = {sx, sy, sz};
-        double globalSum[3] = {0.0, 0.0, 0.0};
-        ippl::Comm->allreduce(&localSum[0], &globalSum[0], 3, std::plus<double>());
-        const size_t Nglob = this->getTotalNum();
-        const double Norm  = Nglob == 0 ? 1.0 : static_cast<double>(Nglob);
-        mean[0]            = globalSum[0] / Norm;
-        mean[1]            = globalSum[1] / Norm;
-        mean[2]            = globalSum[2] / Norm;
-        return mean;
-    }
+    /// Returns the zero vector when the container does not track spin (the
+    /// moments are then never computed and stay zeroed by reset()).
+    Vector_t<double, 3> getMeanPol() const { return distMoments_m.getMeanPolarization(); }
 
     /// Per-component RMS of the polarization vector across the bunch.
     /// Defined as $\sqrt{\langle P_i^2\rangle - \langle P_i\rangle^2}$. Returns
     /// the zero vector when the container does not track spin.
     Vector_t<double, 3> getRmsPol() const {
-        Vector_t<double, 3> rms(0.0);
-        if (!spinEnabled_m) {
-            return rms;
-        }
-        const size_t nLocal = this->getLocalNum();
-        auto Polview        = Pol.getView();
-        double s1x = 0.0, s1y = 0.0, s1z = 0.0;
-        double s2x = 0.0, s2y = 0.0, s2z = 0.0;
-        Kokkos::parallel_reduce(
-                "ParticleContainer::getRmsPol", nLocal,
-                KOKKOS_LAMBDA(
-                        const size_t i, double& l1x, double& l1y, double& l1z, double& l2x,
-                        double& l2y, double& l2z) {
-                    const double px = static_cast<double>(Polview(i)[0]);
-                    const double py = static_cast<double>(Polview(i)[1]);
-                    const double pz = static_cast<double>(Polview(i)[2]);
-                    l1x += px;
-                    l1y += py;
-                    l1z += pz;
-                    l2x += px * px;
-                    l2y += py * py;
-                    l2z += pz * pz;
-                },
-                s1x, s1y, s1z, s2x, s2y, s2z);
-        Kokkos::fence();
-        double localSums[6]  = {s1x, s1y, s1z, s2x, s2y, s2z};
-        double globalSums[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-        ippl::Comm->allreduce(&localSums[0], &globalSums[0], 6, std::plus<double>());
-        const size_t Nglob = this->getTotalNum();
-        const double Norm  = Nglob == 0 ? 1.0 : static_cast<double>(Nglob);
-        for (int k = 0; k < 3; ++k) {
-            const double mean  = globalSums[k] / Norm;
-            const double mean2 = globalSums[k + 3] / Norm;
-            const double var   = mean2 - mean * mean;
-            rms[k]             = var > 0.0 ? Kokkos::sqrt(var) : 0.0;
-        }
-        return rms;
+        return distMoments_m.getStandardDeviationPolarization();
     }
 
     /// Magnitude of the mean polarization vector, $|\langle \vec P \rangle|$.

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -259,6 +259,87 @@ public:
 
     Vector_t<double, 3> getRmsRP() const { return distMoments_m.getStandardDeviationRP(); }
 
+    /// Mean polarization vector across the bunch: $\langle \vec P \rangle$.
+    /// Returns the zero vector when the container does not track spin.
+    Vector_t<double, 3> getMeanPol() const {
+        Vector_t<double, 3> mean(0.0);
+        if (!spinEnabled_m) {
+            return mean;
+        }
+        const size_t nLocal = this->getLocalNum();
+        auto Polview        = Pol.getView();
+        double sx = 0.0, sy = 0.0, sz = 0.0;
+        Kokkos::parallel_reduce(
+                "ParticleContainer::getMeanPol", nLocal,
+                KOKKOS_LAMBDA(const size_t i, double& lsx, double& lsy, double& lsz) {
+                    lsx += static_cast<double>(Polview(i)[0]);
+                    lsy += static_cast<double>(Polview(i)[1]);
+                    lsz += static_cast<double>(Polview(i)[2]);
+                },
+                sx, sy, sz);
+        Kokkos::fence();
+        double localSum[3]  = {sx, sy, sz};
+        double globalSum[3] = {0.0, 0.0, 0.0};
+        ippl::Comm->allreduce(&localSum[0], &globalSum[0], 3, std::plus<double>());
+        const size_t Nglob = this->getTotalNum();
+        const double Norm  = Nglob == 0 ? 1.0 : static_cast<double>(Nglob);
+        mean[0]            = globalSum[0] / Norm;
+        mean[1]            = globalSum[1] / Norm;
+        mean[2]            = globalSum[2] / Norm;
+        return mean;
+    }
+
+    /// Per-component RMS of the polarization vector across the bunch.
+    /// Defined as $\sqrt{\langle P_i^2\rangle - \langle P_i\rangle^2}$. Returns
+    /// the zero vector when the container does not track spin.
+    Vector_t<double, 3> getRmsPol() const {
+        Vector_t<double, 3> rms(0.0);
+        if (!spinEnabled_m) {
+            return rms;
+        }
+        const size_t nLocal = this->getLocalNum();
+        auto Polview        = Pol.getView();
+        double s1x = 0.0, s1y = 0.0, s1z = 0.0;
+        double s2x = 0.0, s2y = 0.0, s2z = 0.0;
+        Kokkos::parallel_reduce(
+                "ParticleContainer::getRmsPol", nLocal,
+                KOKKOS_LAMBDA(
+                        const size_t i, double& l1x, double& l1y, double& l1z, double& l2x,
+                        double& l2y, double& l2z) {
+                    const double px = static_cast<double>(Polview(i)[0]);
+                    const double py = static_cast<double>(Polview(i)[1]);
+                    const double pz = static_cast<double>(Polview(i)[2]);
+                    l1x += px;
+                    l1y += py;
+                    l1z += pz;
+                    l2x += px * px;
+                    l2y += py * py;
+                    l2z += pz * pz;
+                },
+                s1x, s1y, s1z, s2x, s2y, s2z);
+        Kokkos::fence();
+        double localSums[6]  = {s1x, s1y, s1z, s2x, s2y, s2z};
+        double globalSums[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        ippl::Comm->allreduce(&localSums[0], &globalSums[0], 6, std::plus<double>());
+        const size_t Nglob = this->getTotalNum();
+        const double Norm  = Nglob == 0 ? 1.0 : static_cast<double>(Nglob);
+        for (int k = 0; k < 3; ++k) {
+            const double mean  = globalSums[k] / Norm;
+            const double mean2 = globalSums[k + 3] / Norm;
+            const double var   = mean2 - mean * mean;
+            rms[k]             = var > 0.0 ? Kokkos::sqrt(var) : 0.0;
+        }
+        return rms;
+    }
+
+    /// Magnitude of the mean polarization vector, $|\langle \vec P \rangle|$.
+    /// This is the standard depolarization observable — distinct from
+    /// $\langle |\vec P|\rangle$.
+    double getMeanPolMagnitude() const {
+        const Vector_t<double, 3> mean = getMeanPol();
+        return Kokkos::sqrt(mean[0] * mean[0] + mean[1] * mean[1] + mean[2] * mean[2]);
+    }
+
     void computeMinMaxR() {
         size_t Nlocal = this->getLocalNum();
         distMoments_m.computeMinMaxPosition(this->R.getView(), Nlocal);

--- a/src/Structure/H5PartWrapperForPT.cpp
+++ b/src/Structure/H5PartWrapperForPT.cpp
@@ -491,6 +491,24 @@ void H5PartWrapperForPT::writeStepData(PartBunch_t* bunch, size_t particleContai
         i32buffer[i] = sp;
     WRITEDATA(Int32, file_m, "sp", i32buffer);
 
+    if (pc->hasSpin()) {
+        auto PolViewDevice = pc->Pol.getView();
+        auto PolView       = Kokkos::create_mirror_view(PolViewDevice);
+        Kokkos::deep_copy(PolView, PolViewDevice);
+
+        for (size_t i = 0; i < numLocalParticles; ++i)
+            f64buffer[i] = static_cast<h5_float64_t>(PolView(i)(0));
+        WRITEDATA(Float64, file_m, "polx", f64buffer);
+
+        for (size_t i = 0; i < numLocalParticles; ++i)
+            f64buffer[i] = static_cast<h5_float64_t>(PolView(i)(1));
+        WRITEDATA(Float64, file_m, "poly", f64buffer);
+
+        for (size_t i = 0; i < numLocalParticles; ++i)
+            f64buffer[i] = static_cast<h5_float64_t>(PolView(i)(2));
+        WRITEDATA(Float64, file_m, "polz", f64buffer);
+    }
+
     if (Options::ebDump) {
         auto EViewDevice = pc->E.getView();
         auto EView       = Kokkos::create_mirror_view(EViewDevice);

--- a/src/Structure/LossDataSink.cpp
+++ b/src/Structure/LossDataSink.cpp
@@ -967,11 +967,11 @@ void LossDataSink::saveASCII() {
             data[nDblColumns * i + 5] = particle.getPz();
             data[nDblColumns * i + 6] = particle.getTime();
             if (hasPolData_m) {
-                const bool has         = particle.hasPol();
+                const bool has               = particle.hasPol();
                 const Vector_t<double, 3>& p = particle.getPol();
-                data[nDblColumns * i + 7] = has ? p(0) : 0.0;
-                data[nDblColumns * i + 8] = has ? p(1) : 0.0;
-                data[nDblColumns * i + 9] = has ? p(2) : 0.0;
+                data[nDblColumns * i + 7]    = has ? p(0) : 0.0;
+                data[nDblColumns * i + 8]    = has ? p(1) : 0.0;
+                data[nDblColumns * i + 9]    = has ? p(2) : 0.0;
             }
         }
 

--- a/src/Structure/LossDataSink.cpp
+++ b/src/Structure/LossDataSink.cpp
@@ -589,7 +589,11 @@ void LossDataSink::writeHeaderASCII() {
         if (hasTurn) {
             os_m << ",  turn ( ), bunchNumber ( )";
         }
-        os_m << ", time (s)" << std::endl;
+        os_m << ", time (s)";
+        if (hasPolData_m) {
+            os_m << ",  polx ( ),  poly ( ),  polz ( )";
+        }
+        os_m << std::endl;
     }
 }
 
@@ -625,6 +629,9 @@ void LossDataSink::addParticle(
     }
 
     particles_m.push_back(particle);
+    if (particle.hasPol()) {
+        hasPolData_m = true;
+    }
 }
 
 void LossDataSink::save(unsigned int numSets, OpalData::OpenMode openMode) {
@@ -634,6 +641,16 @@ void LossDataSink::save(unsigned int numSets, OpalData::OpenMode openMode) {
     if (openMode == OpalData::OpenMode::UNDEFINED) {
         openMode = OpalData::getInstance()->getOpenMode();
     }
+
+    // hasPolData_m is set per-rank by addParticle(). A rank with no Pol-carrying
+    // particles in this batch must still emit the Pol columns if any other rank
+    // does, so the file format stays consistent across writers. Use a plus-reduction
+    // on the {0,1} flag (IPPL's allreduce supports std::plus); the result is the
+    // count of ranks that saw Pol, which is positive iff any did.
+    int localHas  = hasPolData_m ? 1 : 0;
+    int globalHas = 0;
+    ippl::Comm->allreduce(localHas, globalHas, 1, std::plus<int>());
+    hasPolData_m = (globalHas > 0);
 
     namespace fs = std::filesystem;
     if (h5hut_mode_m) {
@@ -890,6 +907,23 @@ void LossDataSink::saveH5(unsigned int setIdx) {
     });
     writeDataFloat64("time", f64buffer);
 
+    if (hasPolData_m) {
+        ::f64transform(particles_m, startIdx, nLoc, f64buffer, [](const OpalParticle& particle) {
+            return particle.hasPol() ? particle.getPol()(0) : 0.0;
+        });
+        writeDataFloat64("polx", f64buffer);
+
+        ::f64transform(particles_m, startIdx, nLoc, f64buffer, [](const OpalParticle& particle) {
+            return particle.hasPol() ? particle.getPol()(1) : 0.0;
+        });
+        writeDataFloat64("poly", f64buffer);
+
+        ::f64transform(particles_m, startIdx, nLoc, f64buffer, [](const OpalParticle& particle) {
+            return particle.hasPol() ? particle.getPol()(2) : 0.0;
+        });
+        writeDataFloat64("polz", f64buffer);
+    }
+
     ++H5call_m;
 }
 
@@ -916,20 +950,29 @@ void LossDataSink::saveASCII() {
 
     const std::size_t nLoc        = particles_m.size();
     const std::size_t nIntColumns = hasTurn ? 3 : 1;
+    // Per-particle double column count: x, y, z, px, py, pz, time (+ polx, poly, polz)
+    const std::size_t nDblColumns = hasPolData_m ? 10 : 7;
 
     auto packDoubleData = [&]() {
-        std::vector<double> data(7 * nLoc);
+        std::vector<double> data(nDblColumns * nLoc);
 
         for (std::size_t i = 0; i < nLoc; ++i) {
             const OpalParticle& particle = particles_m[i];
 
-            data[7 * i + 0] = particle.getX();
-            data[7 * i + 1] = particle.getY();
-            data[7 * i + 2] = particle.getZ();
-            data[7 * i + 3] = particle.getPx();
-            data[7 * i + 4] = particle.getPy();
-            data[7 * i + 5] = particle.getPz();
-            data[7 * i + 6] = particle.getTime();
+            data[nDblColumns * i + 0] = particle.getX();
+            data[nDblColumns * i + 1] = particle.getY();
+            data[nDblColumns * i + 2] = particle.getZ();
+            data[nDblColumns * i + 3] = particle.getPx();
+            data[nDblColumns * i + 4] = particle.getPy();
+            data[nDblColumns * i + 5] = particle.getPz();
+            data[nDblColumns * i + 6] = particle.getTime();
+            if (hasPolData_m) {
+                const bool has         = particle.hasPol();
+                const Vector_t<double, 3>& p = particle.getPol();
+                data[nDblColumns * i + 7] = has ? p(0) : 0.0;
+                data[nDblColumns * i + 8] = has ? p(1) : 0.0;
+                data[nDblColumns * i + 9] = has ? p(2) : 0.0;
+            }
         }
 
         return data;
@@ -956,12 +999,12 @@ void LossDataSink::saveASCII() {
     auto writeRecords = [&](const std::vector<double>& doubleData,
                             const std::vector<long long>& integerData, std::size_t count) {
         for (std::size_t i = 0; i < count; ++i) {
-            os_m << doubleData[7 * i + 0] << "   ";
-            os_m << doubleData[7 * i + 1] << "   ";
-            os_m << doubleData[7 * i + 2] << "   ";
-            os_m << doubleData[7 * i + 3] << "   ";
-            os_m << doubleData[7 * i + 4] << "   ";
-            os_m << doubleData[7 * i + 5] << "   ";
+            os_m << doubleData[nDblColumns * i + 0] << "   ";
+            os_m << doubleData[nDblColumns * i + 1] << "   ";
+            os_m << doubleData[nDblColumns * i + 2] << "   ";
+            os_m << doubleData[nDblColumns * i + 3] << "   ";
+            os_m << doubleData[nDblColumns * i + 4] << "   ";
+            os_m << doubleData[nDblColumns * i + 5] << "   ";
             os_m << integerData[nIntColumns * i + 0] << "   ";
 
             if (hasTurn) {
@@ -969,7 +1012,13 @@ void LossDataSink::saveASCII() {
                 os_m << integerData[nIntColumns * i + 2] << "   ";
             }
 
-            os_m << doubleData[7 * i + 6] << std::endl;
+            os_m << doubleData[nDblColumns * i + 6];
+            if (hasPolData_m) {
+                os_m << "   " << doubleData[nDblColumns * i + 7];
+                os_m << "   " << doubleData[nDblColumns * i + 8];
+                os_m << "   " << doubleData[nDblColumns * i + 9];
+            }
+            os_m << std::endl;
         }
     };
 
@@ -986,7 +1035,7 @@ void LossDataSink::saveASCII() {
                     &remoteCount, 1, MPI_UNSIGNED_LONG_LONG, src, tagCount, comm,
                     MPI_STATUS_IGNORE);
 
-            std::vector<double> remoteDoubleData(7 * remoteCount);
+            std::vector<double> remoteDoubleData(nDblColumns * remoteCount);
             std::vector<long long> remoteIntegerData(nIntColumns * remoteCount);
 
             if (remoteCount > 0) {

--- a/src/Structure/LossDataSink.h
+++ b/src/Structure/LossDataSink.h
@@ -183,6 +183,10 @@ private:
     std::vector<size_t> bunchNumber_m;
     std::vector<size_t> turnNumber_m;
 
+    /// True once any particle added through addParticle() carried a polarization
+    /// vector. Controls whether polx/poly/polz columns appear in the lossfile.
+    bool hasPolData_m = false;
+
     std::vector<Vector_t<double, 3>> RefPartR_m;
     std::vector<Vector_t<double, 3>> RefPartP_m;
     std::vector<h5_int64_t> globalTrackStep_m;

--- a/src/Structure/StatWriter.cpp
+++ b/src/Structure/StatWriter.cpp
@@ -115,8 +115,7 @@ void StatWriter::fillHeader(const losses_t& losses, const std::string& species, 
         columns_m.addColumn("mean_polx", "double", "1", "Mean polarization x");
         columns_m.addColumn("mean_poly", "double", "1", "Mean polarization y");
         columns_m.addColumn("mean_polz", "double", "1", "Mean polarization z");
-        columns_m.addColumn(
-                "mean_pol_mag", "double", "1", "Magnitude of mean polarization vector");
+        columns_m.addColumn("mean_pol_mag", "double", "1", "Magnitude of mean polarization vector");
         columns_m.addColumn("rms_polx", "double", "1", "RMS polarization x");
         columns_m.addColumn("rms_poly", "double", "1", "RMS polarization y");
         columns_m.addColumn("rms_polz", "double", "1", "RMS polarization z");

--- a/src/Structure/StatWriter.cpp
+++ b/src/Structure/StatWriter.cpp
@@ -40,7 +40,7 @@
 
 StatWriter::StatWriter(const std::string& fname, bool restart) : StatBaseWriter(fname, restart) {}
 
-void StatWriter::fillHeader(const losses_t& losses, const std::string& species) {
+void StatWriter::fillHeader(const losses_t& losses, const std::string& species, bool hasSpin) {
     if (this->hasColumns()) {
         return;
     }
@@ -110,6 +110,17 @@ void StatWriter::fillHeader(const losses_t& losses, const std::string& species) 
     columns_m.addColumn(
             "nBins", "int", "1",
             "Number of field solver bins, potentially after adaptive binning.");
+
+    if (hasSpin) {
+        columns_m.addColumn("mean_polx", "double", "1", "Mean polarization x");
+        columns_m.addColumn("mean_poly", "double", "1", "Mean polarization y");
+        columns_m.addColumn("mean_polz", "double", "1", "Mean polarization z");
+        columns_m.addColumn(
+                "mean_pol_mag", "double", "1", "Magnitude of mean polarization vector");
+        columns_m.addColumn("rms_polx", "double", "1", "RMS polarization x");
+        columns_m.addColumn("rms_poly", "double", "1", "RMS polarization y");
+        columns_m.addColumn("rms_polz", "double", "1", "RMS polarization z");
+    }
 
     /// \todo Options::computePercentiles needs to be brought back
     /*
@@ -239,7 +250,7 @@ void StatWriter::write(
         return;
     }
 
-    fillHeader(losses, species);
+    fillHeader(losses, species, pc->hasSpin());
 
     this->open();
 
@@ -342,6 +353,18 @@ void StatWriter::write(
     columns_m.addColumnValue("temperature", temperature);           // 44 Temperature
     columns_m.addColumnValue("rmsDensity", beam.get_rmsDensity());  // 45 RMS number density
     columns_m.addColumnValue("nBins", beam.getCurrentNBins());
+
+    if (pc->hasSpin()) {
+        const Vector_t<double, 3> meanPol = pc->getMeanPol();
+        const Vector_t<double, 3> rmsPol  = pc->getRmsPol();
+        columns_m.addColumnValue("mean_polx", meanPol(0));
+        columns_m.addColumnValue("mean_poly", meanPol(1));
+        columns_m.addColumnValue("mean_polz", meanPol(2));
+        columns_m.addColumnValue("mean_pol_mag", pc->getMeanPolMagnitude());
+        columns_m.addColumnValue("rms_polx", rmsPol(0));
+        columns_m.addColumnValue("rms_poly", rmsPol(1));
+        columns_m.addColumnValue("rms_polz", rmsPol(2));
+    }
 
     /*
     if (Options::computePercentiles) {

--- a/src/Structure/StatWriter.h
+++ b/src/Structure/StatWriter.h
@@ -50,7 +50,9 @@ public:
             size_t particleContainerIndex = 0);
 
 private:
-    void fillHeader(const losses_t& losses = losses_t(), const std::string& species = "");
+    void fillHeader(
+            const losses_t& losses = losses_t(), const std::string& species = "",
+            bool hasSpin = false);
 };
 
 #endif


### PR DESCRIPTION
# Summary
This PR addresses the issue #439 and adds the spin polarisation attribute to the quantities written to the output files. 
The file formats are unchanged for non-spin-tracking runs. 

### Additions

**`.stat` file** (`StatWriter`)
- New columns, emitted only when `pc->hasSpin()`: `mean_polx/y/z`, `mean_pol_mag`,
  `rms_polx/y/z`.

**H5 phase-space dump** (`H5PartWrapperForPT::writeStepData`)
- Writes `polx`, `poly`, `polz` datasets per step when the container tracks spin.

**Loss / monitor files** (`LossDataSink`, `Monitor`)
- `OpalParticle` gains an optional polarisation vector (new ctor overload + `hasPol()` /
  `getPol()` / `setPol()`); `Monitor::apply` / `driftToCorrectPositionAndSave` attach it
  when the container has spin.
- `LossDataSink` emits `polx/poly/polz` in both ASCII and H5 loss output. 

**Polarisation Moments calculated in** `DistributionMoments`
- Moments of the particle-wise polarisation vectors calculated in `computePolarizationMoments()` which intern is called in `updateMoments()`.

### Testing
Compiles and passes unit tests and regression tests on CPU and GPU. 


