### PR TITLE
Hip dualview

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -129,6 +129,20 @@ set(_opalx_fetchcontent_updates_disconnected "${FETCHCONTENT_UPDATES_DISCONNECTE
 if(NOT _opalx_ippl_git_shallow)
     set(FETCHCONTENT_UPDATES_DISCONNECTED OFF)
 endif()
+
+
+# Kokkos 5 removed this toggle: DualView modify checks are always enabled.
+# A stale cache entry or old site preset that sets it to OFF makes Kokkos fail
+# during option validation, so remove it before IPPL adds Kokkos.
+
+if(DEFINED Kokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK)
+    unset(Kokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK)
+    unset(Kokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK CACHE)
+endif()
+
+
+
+
 FetchContent_MakeAvailable(IPPL)
 set(FETCHCONTENT_UPDATES_DISCONNECTED "${_opalx_fetchcontent_updates_disconnected}")
 message(STATUS "IPPL fetched ref: ${_opalx_ippl_fetch_ref}")

--- a/src/Fields/Astra1DDynamic.cpp
+++ b/src/Fields/Astra1DDynamic.cpp
@@ -254,8 +254,8 @@ void Astra1DDynamic::readMap() {
     delete[] zvals;
     delete[] RealValues;
 
-    FourCoefs_m.modify<Kokkos::HostSpace>();
-    FourCoefs_m.sync<Kokkos::DefaultExecutionSpace>();
+    FourCoefs_m.modify<typename decltype(FourCoefs_m)::host_mirror_space>();
+    FourCoefs_m.sync<typename decltype(FourCoefs_m)::t_dev::device_type>();
 
     Inform m("Astra1DDynamic::readMap");
     m << level3 << "Read in fieldmap '" << Filename_m << "'" << endl;

--- a/src/Fields/Astra1DMagnetoStatic.cpp
+++ b/src/Fields/Astra1DMagnetoStatic.cpp
@@ -243,8 +243,8 @@ void Astra1DMagnetoStatic::readMap() {
     delete[] zvals;
     delete[] RealValues;
 
-    FourCoefs_m.modify<Kokkos::HostSpace>();
-    FourCoefs_m.sync<Kokkos::DefaultExecutionSpace>();
+    FourCoefs_m.modify<typename decltype(FourCoefs_m)::host_mirror_space>();
+    FourCoefs_m.sync<typename decltype(FourCoefs_m)::t_dev::device_type>();
 
     Inform m("Astra1DMagnetoStatic::readMap");
     m << level3 << "Read in fieldmap '" << Filename_m << "'" << endl;

--- a/src/Fields/FM2DDynamic.cpp
+++ b/src/Fields/FM2DDynamic.cpp
@@ -174,14 +174,14 @@ void FM2DDynamic::readMap() {
             Bt(i) *= scaleB;
         }
 
-        FieldstrengthEz_m.modify<Kokkos::HostSpace>();
-        FieldstrengthEz_m.sync<Kokkos::DefaultExecutionSpace>();
+        FieldstrengthEz_m.modify<typename decltype(FieldstrengthEz_m)::host_mirror_space>();
+        FieldstrengthEz_m.sync<typename decltype(FieldstrengthEz_m)::t_dev::device_type>();
 
-        FieldstrengthEr_m.modify<Kokkos::HostSpace>();
-        FieldstrengthEr_m.sync<Kokkos::DefaultExecutionSpace>();
+        FieldstrengthEr_m.modify<typename decltype(FieldstrengthEr_m)::host_mirror_space>();
+        FieldstrengthEr_m.sync<typename decltype(FieldstrengthEr_m)::t_dev::device_type>();
 
-        FieldstrengthBt_m.modify<Kokkos::HostSpace>();
-        FieldstrengthBt_m.sync<Kokkos::DefaultExecutionSpace>();
+        FieldstrengthBt_m.modify<typename decltype(FieldstrengthBt_m)::host_mirror_space>();
+        FieldstrengthBt_m.sync<typename decltype(FieldstrengthBt_m)::t_dev::device_type>();
 
         Inform m("FM2DDynamic::readMap");
         m << level3 << "Read in fieldmap '" << Filename_m << "'" << endl;

--- a/src/Fields/FM2DMagnetoStatic.cpp
+++ b/src/Fields/FM2DMagnetoStatic.cpp
@@ -167,10 +167,11 @@ void FM2DMagnetoStatic::readMap() {
             }
         }
 
-        FieldstrengthBz_m.modify<Kokkos::HostSpace>();
-        FieldstrengthBz_m.sync<Kokkos::DefaultExecutionSpace>();
-        FieldstrengthBr_m.modify<Kokkos::HostSpace>();
-        FieldstrengthBr_m.sync<Kokkos::DefaultExecutionSpace>();
+        FieldstrengthBz_m.modify<typename decltype(FieldstrengthBz_m)::host_mirror_space>();
+        FieldstrengthBz_m.sync<typename decltype(FieldstrengthBz_m)::t_dev::device_type>();
+
+        FieldstrengthBr_m.modify<typename decltype(FieldstrengthBr_m)::host_mirror_space>();
+        FieldstrengthBr_m.sync<typename decltype(FieldstrengthBr_m)::t_dev::device_type>();
 
         *ippl::Info << level3 << typeset_msg("read in fieldmap '" + Filename_m + "'", "info")
                     << endl;


### PR DESCRIPTION
This fixes a dualview memory/execution space type deduction problem on HIP/rocm builds at CSCS
Also includes a patch for cmake dualview checks 