### PR TITLE
Calculate Initial Reference Position from Particles

### DIFF
--- a/src/Algorithms/ParallelTracker.cpp
+++ b/src/Algorithms/ParallelTracker.cpp
@@ -206,35 +206,59 @@ void ParallelTracker::execute() {
                     "Particle container has null PartData reference during lab-frame init.");
         }
         pc->setToLabTrafo(beamlineToLab);
-        pc->getRefPartR() = beamlineToLab.transformTo(Vector_t<double, 3>(0, 0, 0));
+
+        // Resolve the reference particle's pose in the beamline frame. Position and
+        // momentum follow the same 3-tier rule: the bunch mean when particles already
+        // exist; otherwise the input-specified emission offsets (R0, P0) reported by
+        // the sampler; otherwise the design pose (lattice origin, beta*gamma along +z).
+        Vector_t<double, 3> refR = 0.0;
+        Vector_t<double, 3> refP = 0.0;
         if (pc->getTotalNum() > 0) {
-            pc->getRefPartP() = beamlineToLab.rotateTo(pc->getMeanP());
+            refR = pc->getMeanR();
+            refP = pc->getMeanP();
         } else {
-            bool useSamplerReference        = false;
+            // Empty container (e.g. an emitted distribution before its first emission):
+            // the bunch mean is undefined, so take the emission offsets from the sampler.
+            bool useSamplerPosition         = false;
+            bool useSamplerMomentum         = false;
+            Vector_t<double, 3> samplerRefR = 0.0;
             Vector_t<double, 3> samplerRefP = 0.0;
             if (ci < emittingSamplers_m.size()) {
                 for (const auto& sampler : emittingSamplers_m[ci]) {
-                    if (sampler && sampler->hasInitialReferenceMomentum()) {
-                        samplerRefP         = sampler->getInitialReferenceMomentum();
-                        useSamplerReference = true;
-                        break;
+                    if (!sampler) {
+                        continue;
+                    }
+                    if (!useSamplerMomentum && sampler->hasInitialReferenceMomentum()) {
+                        samplerRefP        = sampler->getInitialReferenceMomentum();
+                        useSamplerMomentum = true;
+                    }
+                    if (!useSamplerPosition && sampler->hasInitialReferencePosition()) {
+                        samplerRefR        = sampler->getInitialReferencePosition();
+                        useSamplerPosition = true;
                     }
                 }
             }
 
-            if (useSamplerReference) {
+            // Position: emission offset R0, else the lattice origin.
+            refR = useSamplerPosition ? samplerRefR : Vector_t<double, 3>(0.0);
+
+            // Momentum: emission offset P0, else the design beta*gamma along +z.
+            if (useSamplerMomentum) {
                 if (dot(samplerRefP, samplerRefP) <= 0.0) {
                     throw OpalException(
                             "ParallelTracker::execute",
                             "Sampler-provided initial reference momentum is zero.");
                 }
-                pc->getRefPartP() = beamlineToLab.rotateTo(samplerRefP);
+                refP = samplerRefP;
             } else {
                 const PartData& pref = *pc->getReference();
                 const double P0      = pref.getP() / pref.getM();  // beta*gamma from BEAM pc
-                pc->getRefPartP()    = beamlineToLab.rotateTo(Vector_t<double, 3>(0.0, 0.0, P0));
+                refP                 = Vector_t<double, 3>(0.0, 0.0, P0);
             }
         }
+
+        pc->getRefPartR() = beamlineToLab.transformTo(refR);
+        pc->getRefPartP() = beamlineToLab.rotateTo(refP);
     }
 
     m << level4

--- a/src/Distribution/EmittedFromFile.h
+++ b/src/Distribution/EmittedFromFile.h
@@ -92,6 +92,21 @@ public:
     Vector_t<double, 3> getInitialReferenceMomentum() const override { return initialRefP_m; }
 
     /**
+     * @brief Reports that this sampler provides an initial reference position.
+     *
+     * @return True after the file inventory has been built.
+     */
+    bool hasInitialReferencePosition() const override { return inventoryBuilt_m; }
+
+    /**
+     * @brief Returns the initial reference position used by the tracker.
+     *
+     * @return The emission-source position offset R0 (the emission point); particles
+     *         are born symmetric about it, so no per-record average is needed.
+     */
+    Vector_t<double, 3> getInitialReferencePosition() const override { return R0_m; }
+
+    /**
      * @brief Returns the global time shift needed to center old-OPAL file times.
      *
      * @return Non-negative shift from source time to the midpoint of the emission window.

--- a/src/Distribution/OpalFlatTop.h
+++ b/src/Distribution/OpalFlatTop.h
@@ -123,6 +123,19 @@ public:
     Vector_t<double, 3> getInitialReferenceMomentum() const override;
 
     /**
+     * @brief Reports that this sampler provides an initial reference position.
+     */
+    bool hasInitialReferencePosition() const override { return true; }
+
+    /**
+     * @brief Returns the initial reference position used by the tracker.
+     *
+     * @return The emission-source position offset R0 (the emission point). Unlike
+     *         momentum, the emission model does not transform the position.
+     */
+    Vector_t<double, 3> getInitialReferencePosition() const override { return R0_m; }
+
+    /**
      * @brief Returns the preferred emission time step.
      *
      * @return emissionTime divided by the configured number of emission steps.

--- a/src/Distribution/SamplingBase.hpp
+++ b/src/Distribution/SamplingBase.hpp
@@ -98,6 +98,13 @@ public:
         return Vector_t<double, 3>(0.0);
     }
 
+    /// @brief Optional initial reference position in the source-local frame.
+    virtual bool hasInitialReferencePosition() const { return false; }
+
+    virtual Vector_t<double, 3> getInitialReferencePosition() const {
+        return Vector_t<double, 3>(0.0);
+    }
+
     /// @brief Optional OPAL-like tracker time step while this sampler is still emitting.
     virtual double getEmissionTimeStep() const { return 0.0; }
 


### PR DESCRIPTION
This PR addresses the issue #459. 

The initial `RefPartR` is now calculated in the following way:
1. If there are particles at $t=0$, `getMeanR()` of the particles.
2. If there are no particles but a sampler with an initial reference position, `getInitialReferencePosition()`
3. If there are no particles and no sampler, `RefPartR = {0,0,0}`

This mirrors what is already done for `RefPartP`.

closes #459.