### PR TITLE
Add .dat file write guard to rank 0 in auto phaser

### DIFF
--- a/src/Algorithms/CavityAutophaser.cpp
+++ b/src/Algorithms/CavityAutophaser.cpp
@@ -152,7 +152,7 @@ double CavityAutophaser::getPhaseAtMaxEnergy(
 
         newPhase = std::fmod(newPhase + basePhase, Physics::two_pi);
 
-        if (!opal->isOptimizerRun()) {
+        if (!opal->isOptimizerRun() && ippl::Comm->rank() == 0) {
             std::string fname = Util::combineFilePath(
                     {opal->getAuxiliaryOutputDirectory(), itsCavity_m->getName() + "_AP.dat"});
             std::ofstream out(fname);

--- a/src/PartBunch/Binning/AdaptBins.tpp
+++ b/src/PartBunch/Binning/AdaptBins.tpp
@@ -143,6 +143,7 @@ namespace ParticleBinning {
         if (bunch_m.getLocalNum() <= 1) {
             msg << level4 << "Too few bins, assigning all bins to index 0." << endl;
             Kokkos::deep_copy(binIndex, 0);
+            IpplTimings::stopTimer(bAssignUniformBinsT);
             return;
         }
 


### PR DESCRIPTION
closes #480 

This PR adds a simple guard to the cavity autophaser. The algorithm still runs on every single rank, but the `<cavity>_AP.dat` files are now only written once on rank 0. This means no more file system write contention and saves a lot of runtime on large node counts. The same test as described in the issue (`SwissFEL-booster-sc`, $128^3$ and 64 ranks) now takes:
```text
Timings{0}> OrbThreader......... Wall max =     8.8539
Timings{0}>                      Wall avg =    8.58606
Timings{0}>                      Wall min =    8.42476
```
vs. the 400s before. Regression tests and unit tests all pass on CPU as well as on GPU. 
