### PR TITLE
Add missing beam rigidity scaling term in multipole expansion

### DIFF
--- a/src/Elements/OpalMultipole.cpp
+++ b/src/Elements/OpalMultipole.cpp
@@ -86,14 +86,19 @@ void OpalMultipole::update() {
 
     unsigned int top = (normSize > skewSize) ? normSize : skewSize;
 
+    // KN/KS are NORMALISED strengths [m^-(n+1)]; the components stored/applied by
+    // Multipole are physical field coefficients [T/m^n]. Convert with Brho = P0/c,
+    // one factor for every order, exactly as OpalSBend does (OpalSBend.cpp:71-76).
+    double factor = OpalData::getInstance()->getP0() / Physics::c;
+
     // Loop over components (0=Dipole, 1=Quadrupole, ...) populating the device
     // coefficient views read by Multipole::apply().
     for (unsigned int comp = 0; comp < top; ++comp) {
         if (comp < normSize) {
-            mult->setNormalComponent(comp, norm[comp], normErrors[comp]);
+            mult->setNormalComponent(comp, factor * norm[comp], factor * normErrors[comp]);
         }
         if (comp < skewSize) {
-            mult->setSkewComponent(comp, skew[comp], skewErrors[comp]);
+            mult->setSkewComponent(comp, factor * skew[comp], factor * skewErrors[comp]);
         }
     }
 

--- a/src/Elements/OpalQuadrupole.cpp
+++ b/src/Elements/OpalQuadrupole.cpp
@@ -70,12 +70,12 @@ void OpalQuadrupole::update() {
     // The KN vector convention is: index 0 = dipole, index 1 = quadrupole, ...
     // Populate the device coefficient views read by Multipole::apply().
     // K1 is a NORMALISED strength [m^-2]; the field component stored/applied by
-    // Multipole is a physical gradient [T/m]. 
+    // Multipole is a physical gradient [T/m].
     double factor = OpalData::getInstance()->getP0() / Physics::c;
-    double k1   = Attributes::getReal(itsAttr[K1]) * factor;
-    double dk1  = Attributes::getReal(itsAttr[DK1]) * factor;
-    double k1s  = Attributes::getReal(itsAttr[K1S]) * factor;
-    double dk1s = Attributes::getReal(itsAttr[DK1S]) * factor;
+    double k1     = Attributes::getReal(itsAttr[K1]) * factor;
+    double dk1    = Attributes::getReal(itsAttr[DK1]) * factor;
+    double k1s    = Attributes::getReal(itsAttr[K1S]) * factor;
+    double dk1s   = Attributes::getReal(itsAttr[DK1S]) * factor;
 
     // comp 0 (dipole): strength = 0
     mult->setNormalComponent(0, 0.0, 0.0);

--- a/src/Elements/OpalQuadrupole.cpp
+++ b/src/Elements/OpalQuadrupole.cpp
@@ -69,10 +69,13 @@ void OpalQuadrupole::update() {
 
     // The KN vector convention is: index 0 = dipole, index 1 = quadrupole, ...
     // Populate the device coefficient views read by Multipole::apply().
-    double k1   = Attributes::getReal(itsAttr[K1]);
-    double dk1  = Attributes::getReal(itsAttr[DK1]);
-    double k1s  = Attributes::getReal(itsAttr[K1S]);
-    double dk1s = Attributes::getReal(itsAttr[DK1S]);
+    // K1 is a NORMALISED strength [m^-2]; the field component stored/applied by
+    // Multipole is a physical gradient [T/m]. 
+    double factor = OpalData::getInstance()->getP0() / Physics::c;
+    double k1   = Attributes::getReal(itsAttr[K1]) * factor;
+    double dk1  = Attributes::getReal(itsAttr[DK1]) * factor;
+    double k1s  = Attributes::getReal(itsAttr[K1S]) * factor;
+    double dk1s = Attributes::getReal(itsAttr[DK1S]) * factor;
 
     // comp 0 (dipole): strength = 0
     mult->setNormalComponent(0, 0.0, 0.0);


### PR DESCRIPTION
This PR addresses the issue #490 by adding the correct beam-rigidity scaling term to the normal and skew components.

Closes #490.