### PR TITLE
Explicitly give ParticleSpatialLayout mesh template argument

### DIFF
--- a/src/PartBunch/ImageChargeScatterController.h
+++ b/src/PartBunch/ImageChargeScatterController.h
@@ -29,7 +29,7 @@ class ImageChargeScatterController {
 public:
     using ParticleCtr_t  = ParticleContainer<T, Dim>;
     using PositionAttr_t = typename ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>,
+            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T,Dim>>,
             Kokkos::DefaultExecutionSpace::memory_space>::particle_position_type;
     using RhoField_t  = Field_t<Dim>;
     using BinPolicy_t = Kokkos::RangePolicy<>;

--- a/src/PartBunch/ImageChargeScatterController.h
+++ b/src/PartBunch/ImageChargeScatterController.h
@@ -29,7 +29,7 @@ class ImageChargeScatterController {
 public:
     using ParticleCtr_t  = ParticleContainer<T, Dim>;
     using PositionAttr_t = typename ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>,
+            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
             Kokkos::DefaultExecutionSpace::memory_space>::particle_position_type;
     using RhoField_t  = Field_t<Dim>;
     using BinPolicy_t = Kokkos::RangePolicy<>;

--- a/src/PartBunch/ImageChargeScatterController.h
+++ b/src/PartBunch/ImageChargeScatterController.h
@@ -29,7 +29,7 @@ class ImageChargeScatterController {
 public:
     using ParticleCtr_t  = ParticleContainer<T, Dim>;
     using PositionAttr_t = typename ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim>,
+            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>,
             Kokkos::DefaultExecutionSpace::memory_space>::particle_position_type;
     using RhoField_t  = Field_t<Dim>;
     using BinPolicy_t = Kokkos::RangePolicy<>;

--- a/src/PartBunch/ImageChargeScatterController.h
+++ b/src/PartBunch/ImageChargeScatterController.h
@@ -29,7 +29,7 @@ class ImageChargeScatterController {
 public:
     using ParticleCtr_t  = ParticleContainer<T, Dim>;
     using PositionAttr_t = typename ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T,Dim>>,
+            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
             Kokkos::DefaultExecutionSpace::memory_space>::particle_position_type;
     using RhoField_t  = Field_t<Dim>;
     using BinPolicy_t = Kokkos::RangePolicy<>;

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -14,7 +14,8 @@ using ORB = ippl::OrthogonalRecursiveBisection<Field<double, Dim>, T>;
 template <typename T, unsigned Dim>
 class LoadBalancer {
     using Base = ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
+            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
+            Kokkos::DefaultExecutionSpace::memory_space>;
     using FieldSolver_t = ippl::FieldSolverBase<T, Dim>;
 
 private:
@@ -77,7 +78,8 @@ public:
         // Repartition the domains
 
         using Base = ippl::ParticleBase<
-                ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
+                ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
+                Kokkos::DefaultExecutionSpace::memory_space>;
         typename Base::particle_position_type* R;
         R = &pc_m->R;
 

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -14,7 +14,7 @@ using ORB = ippl::OrthogonalRecursiveBisection<Field<double, Dim>, T>;
 template <typename T, unsigned Dim>
 class LoadBalancer {
     using Base = ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
+            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
     using FieldSolver_t = ippl::FieldSolverBase<T, Dim>;
 
 private:
@@ -77,7 +77,7 @@ public:
         // Repartition the domains
 
         using Base = ippl::ParticleBase<
-                ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
+                ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
         typename Base::particle_position_type* R;
         R = &pc_m->R;
 

--- a/src/PartBunch/PartBunch.h
+++ b/src/PartBunch/PartBunch.h
@@ -58,7 +58,7 @@ public:
     using BinnedFieldSolver_t = BinnedFieldSolver<T, Dim>;
     using LoadBalancer_t      = LoadBalancer<T, Dim>;
     using Base                = ippl::ParticleBase<
-                           ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
+                           ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
 
     using CoordinateSelector_t = typename ParticleBinning::CoordinateSelector<ParticleContainer_t>;
     using GammaSelector_t      = typename ParticleBinning::GammaSelector<ParticleContainer_t>;

--- a/src/PartBunch/PartBunch.h
+++ b/src/PartBunch/PartBunch.h
@@ -58,7 +58,8 @@ public:
     using BinnedFieldSolver_t = BinnedFieldSolver<T, Dim>;
     using LoadBalancer_t      = LoadBalancer<T, Dim>;
     using Base                = ippl::ParticleBase<
-                           ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
+                           ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
+                           Kokkos::DefaultExecutionSpace::memory_space>;
 
     using CoordinateSelector_t = typename ParticleBinning::CoordinateSelector<ParticleContainer_t>;
     using GammaSelector_t      = typename ParticleBinning::GammaSelector<ParticleContainer_t>;

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -63,7 +63,7 @@ using size_type = ippl::detail::size_type;
 template <typename T, unsigned Dim = 3>
 class ParticleContainer
     : public ippl::ParticleBase<
-              ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space> {
+              ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space> {
     /**
      * @brief Alias for the `ippl::ParticleBase` specialization this container inherits from.
      *
@@ -76,7 +76,7 @@ class ParticleContainer
      * `Base::create()`.
      */
     using Base = ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim>, Kokkos::DefaultExecutionSpace::memory_space>;
+            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
 
 private:
     /**

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -63,7 +63,8 @@ using size_type = ippl::detail::size_type;
 template <typename T, unsigned Dim = 3>
 class ParticleContainer
     : public ippl::ParticleBase<
-              ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space> {
+              ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
+              Kokkos::DefaultExecutionSpace::memory_space> {
     /**
      * @brief Alias for the `ippl::ParticleBase` specialization this container inherits from.
      *
@@ -76,7 +77,8 @@ class ParticleContainer
      * `Base::create()`.
      */
     using Base = ippl::ParticleBase<
-            ippl::ParticleSpatialLayout<T, Dim,ippl::UniformCartesian<T,Dim>>, Kokkos::DefaultExecutionSpace::memory_space>;
+            ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>,
+            Kokkos::DefaultExecutionSpace::memory_space>;
 
 private:
     /**


### PR DESCRIPTION
The newest [changes](https://github.com/IPPL-framework/ippl/commit/e744cbf2d371c60562126607fd57396a10db276b#diff-b7bc603bd8c5ac4d8f2280599cdf9e9357bde836b70d843a83d032f300577274) in IPPL remove the default `Mesh` template argument. So we need to explicitly define it everywhere we use `ParticleSpatialLayout`.
Closes #492.