### PR TITLE
After IPPL fixes: Make P3M available in OPALX

### DIFF
--- a/src/Distribution/FlatTop.cpp
+++ b/src/Distribution/FlatTop.cpp
@@ -268,7 +268,7 @@ void FlatTop::initDomainDecomp(double BoxIncr) {
     hr_m                      = (1.0 + BoxIncr / 100.) * (l / nr_m);
     mesh->setMeshSpacing(hr_m);
     mesh->setOrigin(o - 0.5 * hr_m * BoxIncr / 100.);
-    pc_m->getLayout().updateLayout(*FL, *mesh);
+    pc_m->updateLayout(*FL, *mesh);
 }
 
 FlatTop::size_type FlatTop::countEnteringParticlesPerRank(double t0, double tf) {

--- a/src/Distribution/OpalFlatTop.cpp
+++ b/src/Distribution/OpalFlatTop.cpp
@@ -401,7 +401,7 @@ void OpalFlatTop::initDomainDecomp(double BoxIncr) {
     hr_m                            = (1.0 + BoxIncr / 100.0) * (l / nr_m);
     mesh->setMeshSpacing(hr_m);
     mesh->setOrigin(o - 0.5 * hr_m * BoxIncr / 100.0);
-    pc_m->getLayout().updateLayout(*FL, *mesh);
+    pc_m->updateLayout(*FL, *mesh);
 }
 
 void OpalFlatTop::setWithDomainDecomp(bool withDomainDecomp) {

--- a/src/PartBunch/BinnedFieldSolver.h
+++ b/src/PartBunch/BinnedFieldSolver.h
@@ -10,10 +10,48 @@
 #include <string>
 #include <vector>
 
+// The IPPL interaction header relies on declarations provided by Ippl.h.
+// clang-format off
+#include "Ippl.h"
+#include "Interaction/TruncatedGreenParticleInteraction.h"
+// clang-format on
 #include "PartBunch/FieldSolver.hpp"
 #include "PartBunch/ImageChargeScatterController.h"
 #include "PartBunch/PartBunch.h"
+#include "Physics/Physics.h"
 #include "Utilities/OpalException.h"
+
+namespace p3m_detail {
+    template <typename ParticleContainer>
+    class ContainerView {
+    public:
+        explicit ContainerView(const ParticleContainer& pc) : pc_m(pc) {}
+
+        const typename ParticleContainer::P3MLayout_t& getLayout() const {
+            return pc_m.getP3MLayout();
+        }
+
+    private:
+        const ParticleContainer& pc_m;
+    };
+
+    template <typename View>
+    class ChargeView {
+    public:
+        using value_type      = typename View::value_type;
+        using execution_space = typename View::execution_space;
+
+        ChargeView(View charge, bool perParticle) : charge_m(charge), perParticle_m(perParticle) {}
+
+        KOKKOS_INLINE_FUNCTION value_type operator()(size_t i) const {
+            return charge_m(perParticle_m ? i : 0);
+        }
+
+    private:
+        View charge_m;
+        bool perParticle_m;
+    };
+}  // namespace p3m_detail
 
 /**
  * @brief Field solver wrapper that implements the full binned self-field algorithm.
@@ -79,7 +117,7 @@ public:
     /**
      * @brief Construct a binned/legacy-compatible solver.
      *
-     * @param solver     Concrete solver name (e.g. `FFT`, `OPEN`, `CG`, `NONE`).
+     * @param solver     Concrete solver name (e.g. `FFT`, `P3M`, `OPEN`, `CG`, `NONE`).
      * @param rho        Pointer to the mesh charge-density field storage.
      * @param E          Pointer to the mesh electric-field storage (solver output).
      * @param phi        Pointer to the potential-field storage (solver internal use).
@@ -90,11 +128,12 @@ public:
      *                        keep the uniform MAXBINS histogram.
      * @param greensFunction  OPAL `GREENSF` selection (`STANDARD` or `INTEGRATED`) forwarded to
      *                        IPPL's open-boundary FFT solver.
+     * @param p3mCutoff       P3M particle-particle cutoff radius in metres.
      */
     BinnedFieldSolver(
             std::string solver, Field_t<Dim>* rho, VField_t<T, Dim>* E, Field_t<Dim>* phi,
             std::shared_ptr<BCHandler_t> bcHandler, int tablePrintFrequency, bool adaptiveBinning,
-            std::string greensFunction = "STANDARD");
+            std::string greensFunction = "STANDARD", T p3mCutoff = T(0));
 
     /**
      * @brief Compute space-charge self-fields for the given particle bunch.
@@ -236,6 +275,9 @@ private:
      * @param bunch Particle bunch for which to compute self-fields.
      */
     void computeLegacySelfFields(PartBunch_t& bunch);
+
+    /// Add IPPL's short-range P3M interaction to the gathered particle electric field.
+    void applyP3MShortRangeInteraction(ParticleCtr_t& pc);
 
     /**
      * @brief Build and prepare adaptive bins for the current step.

--- a/src/PartBunch/BinnedFieldSolver.tpp
+++ b/src/PartBunch/BinnedFieldSolver.tpp
@@ -10,8 +10,8 @@ template <typename T, unsigned Dim>
 BinnedFieldSolver<T, Dim>::BinnedFieldSolver(
         std::string solver, Field_t<Dim>* rho, VField_t<T, Dim>* E, Field_t<Dim>* phi,
         std::shared_ptr<BCHandler_t> bcHandler, int tablePrintFrequency, bool adaptiveBinning,
-        std::string greensFunction)
-    : FieldSolver<T, Dim>(solver, rho, E, phi, bcHandler, std::move(greensFunction)) {
+        std::string greensFunction, T p3mCutoff)
+    : FieldSolver<T, Dim>(solver, rho, E, phi, bcHandler, std::move(greensFunction), p3mCutoff) {
     scatterAttribute_m    = ScatterAttribute::ChargeQ;
     gatherAttribute_m     = GatherAttribute::ElectricFieldE;
     tablePrintFrequency_m = tablePrintFrequency;
@@ -75,6 +75,11 @@ void BinnedFieldSolver<T, Dim>::computeSelfFields(PartBunch_t& bunch) {
 
     // decide which solver path to run (binned vs legacy).
     const bool hasBins = bunch.hasBinning();
+    if (this->getStype() == "P3M" && hasBins) {
+        throw OpalException(
+                "BinnedFieldSolver::computeSelfFields",
+                "TYPE=P3M does not support BINS. Remove BINS from the FIELDSOLVER definition.");
+    }
 
     m << level4 << "Entry: rank=" << ippl::Comm->rank() << ", localParticles=" << pc->getLocalNum()
       << ", totalParticles=" << pc->getTotalNum() << ", hasBins=" << (hasBins ? 1 : 0)
@@ -531,7 +536,7 @@ void BinnedFieldSolver<T, Dim>::computeLegacySelfFields(PartBunch_t& bunch) {
 
     // Alpine uses net-0 charge for non-OPEN solvers (periodic BCs).
     double shift = 0.0;
-    if (stype != "OPEN") {
+    if (stype != "OPEN" && stype != "P3M") {
         double size = 1.0;
         for (size_t d = 0; d < Dim; ++d) {
             size *= bunch.rmax_m[d] - bunch.rmin_m[d];
@@ -561,7 +566,38 @@ void BinnedFieldSolver<T, Dim>::computeLegacySelfFields(PartBunch_t& bunch) {
                 "Unsupported gather attribute in legacy solver.");
     }
 
+    if (stype == "P3M") {
+        applyP3MShortRangeInteraction(*pc);
+    }
+
     // TABLEPRINTFREQ is binned-mode only; legacy mode intentionally prints nothing.
+}
+
+template <typename T, unsigned Dim>
+void BinnedFieldSolver<T, Dim>::applyP3MShortRangeInteraction(ParticleCtr_t& pc) {
+    if (!pc.hasP3MLayout()) {
+        throw OpalException(
+                "BinnedFieldSolver::applyP3MShortRangeInteraction",
+                "TYPE=P3M requires ParticleSpatialOverlapLayout.");
+    }
+
+    using ContainerView = p3m_detail::ContainerView<ParticleCtr_t>;
+    using ChargeView    = p3m_detail::ChargeView<typename ParticleCtr_t::qm_view_type>;
+    using Interaction   = ippl::TruncatedGreenParticleInteraction<
+              ContainerView, particle_position_type, ChargeView>;
+
+    ContainerView container(pc);
+    ChargeView charge(
+            pc.getQView(), pc.getQMStorageMode() == ParticleCtr_t::QMStorageMode::Attributes);
+
+    ippl::ParameterList params;
+    params.add("rcut", this->getP3MCutoff());
+    params.add("alpha", this->getP3MAlpha());
+    // Raw particle charge is used here, so include epsilon_0 in the short-range coefficient.
+    params.add("force_constant", -1.0 / (4.0 * Physics::pi * Physics::epsilon_0));
+
+    Interaction interaction(container, pc.E, pc.R, charge, params);
+    interaction.solve();
 }
 
 template <typename T, unsigned Dim>

--- a/src/PartBunch/FieldSolver.cpp
+++ b/src/PartBunch/FieldSolver.cpp
@@ -343,6 +343,7 @@ void FieldSolver<double, 3>::initP3MSolver() {
     sp.add("alpha", getP3MAlpha());
     // rho already carries 1/epsilon_0; the sign matches OPALX's gathered electric field.
     sp.add("force_constant", -1.0 / (4.0 * Physics::pi));
+    sp.add("regularization_cutoff", 1.0e-9); // standard PP regularization length
     initSolverWithParams<FFTTruncatedGreenSolver_t<double, 3>>(sp);
 }
 

--- a/src/PartBunch/FieldSolver.cpp
+++ b/src/PartBunch/FieldSolver.cpp
@@ -326,6 +326,27 @@ void FieldSolver<double, 3>::initFFTSolver() {
 }
 
 template <>
+void FieldSolver<double, 3>::initP3MSolver() {
+    if (p3mCutoff_m <= 0.0) {
+        throw OpalException(
+                "FieldSolver::initP3MSolver", "The P3M cutoff radius must be greater than zero.");
+    }
+
+    ippl::ParameterList sp;
+    sp.add("output_type", FFTTruncatedGreenSolver_t<double, 3>::GRAD);
+    sp.add("use_heffte_defaults", false);
+    sp.add("use_pencils", true);
+    sp.add("use_reorder", false);
+    sp.add("use_gpu_aware", true);
+    sp.add("comm", ippl::p2p_pl);
+    sp.add("r2c_direction", 0);
+    sp.add("alpha", getP3MAlpha());
+    // rho already carries 1/epsilon_0; the sign matches OPALX's gathered electric field.
+    sp.add("force_constant", -1.0 / (4.0 * Physics::pi));
+    initSolverWithParams<FFTTruncatedGreenSolver_t<double, 3>>(sp);
+}
+
+template <>
 void FieldSolver<double, 3>::initCGSolver() {
     ippl::ParameterList sp;
     sp.add("output_type", CGSolver_t<double, 3>::GRAD);
@@ -352,6 +373,8 @@ void FieldSolver<double, 3>::initSolver() {
     Inform m;
     if (this->getStype() == "FFT") {
         initFFTSolver();
+    } else if (this->getStype() == "P3M") {
+        initP3MSolver();
     } else if (this->getStype() == "OPEN") {
         initOpenSolver();
     } else if (this->getStype() == "CG") {
@@ -559,7 +582,7 @@ double FieldSolver<double, 3>::getCouplingConstant() const {
 
     /// \todo Verify this before activating a new solver!
     const std::string stype = this->getStype();
-    if (stype == "OPEN") {
+    if (stype == "OPEN" || stype == "P3M") {
         return 1.0 / Physics::epsilon_0;
     } else if (stype == "FFT") {
         return 1.0 / Physics::epsilon_0;
@@ -593,25 +616,3 @@ void FieldSolver<double, 3>::setPotentialBCs() {
     // rho_m->setFieldBC(bc_container);
     m << level4 << "Potential BCs in FieldSolver updated using BCHandler." << endl;
 }
-
-/*
-/// \todo to be implemented...
-template<>
-void FieldSolver<double,3>::initP3MSolver() {
-    //        if constexpr (Dim == 3) {
-    ippl::ParameterList sp;
-    sp.add("output_type", P3MSolver_t<double, 3>::GRAD);
-    sp.add("use_heffte_defaults", false);
-    sp.add("use_pencils", true);
-    sp.add("use_reorder", false);
-    sp.add("use_gpu_aware", true);
-    sp.add("comm", ippl::p2p_pl);
-    sp.add("r2c_direction", 0);
-
-    initSolverWithParams<P3MSolver_t<double, 3>>(sp);
-    //  } else {
-    // throw std::runtime_error("Unsupported dimensionality for P3M solver");
-    // }
-}
-
-*/

--- a/src/PartBunch/FieldSolver.cpp
+++ b/src/PartBunch/FieldSolver.cpp
@@ -343,7 +343,7 @@ void FieldSolver<double, 3>::initP3MSolver() {
     sp.add("alpha", getP3MAlpha());
     // rho already carries 1/epsilon_0; the sign matches OPALX's gathered electric field.
     sp.add("force_constant", -1.0 / (4.0 * Physics::pi));
-    sp.add("regularization_cutoff", 1.0e-9); // standard PP regularization length
+    sp.add("regularization_cutoff", 1.0e-9);  // standard PP regularization length
     initSolverWithParams<FFTTruncatedGreenSolver_t<double, 3>>(sp);
 }
 

--- a/src/PartBunch/FieldSolver.hpp
+++ b/src/PartBunch/FieldSolver.hpp
@@ -16,6 +16,7 @@ private:
     VField_t<T, Dim>* E_m;
     Field_t<Dim>* phi_m;
     std::string greensFunction_m;
+    T p3mCutoff_m;
 
     using BCHandler_t = BCHandler<Dim>;
     std::shared_ptr<BCHandler_t> bcHandler_m;
@@ -26,12 +27,14 @@ private:
 public:
     FieldSolver(
             std::string solver, Field_t<Dim>* rho, VField_t<T, Dim>* E, Field_t<Dim>* phi,
-            std::shared_ptr<BCHandler_t> bcHandler, std::string greensFunction = "STANDARD")
+            std::shared_ptr<BCHandler_t> bcHandler, std::string greensFunction = "STANDARD",
+            T p3mCutoff = T(0))
         : ippl::FieldSolverBase<T, Dim>(solver),
           rho_m(rho),
           E_m(E),
           phi_m(phi),
           greensFunction_m(std::move(greensFunction)),
+          p3mCutoff_m(p3mCutoff),
           bcHandler_m(bcHandler),
           call_counter_m(0) {
         setPotentialBCs();
@@ -73,6 +76,10 @@ public:
     void setGreensFunction(std::string greensFunction) {
         greensFunction_m = std::move(greensFunction);
     }
+
+    T getP3MCutoff() const { return p3mCutoff_m; }
+
+    T getP3MAlpha() const { return T(2) / p3mCutoff_m; }
 
     /**
      * @brief Get the solver's coupling constant.
@@ -184,7 +191,7 @@ public:
 
     void initCGSolver() {}
 
-    void initP3MSolver() {}
+    void initP3MSolver();
 };
 
 // Explicit specialization declaration

--- a/src/PartBunch/LoadBalancer.hpp
+++ b/src/PartBunch/LoadBalancer.hpp
@@ -59,8 +59,7 @@ public:
         fc_m->updateFieldLayoutsAfterLayoutChange(fs_m ? fs_m->getStype() : "");
 
         // Update layout with new FieldLayout
-        PLayout_t<T, Dim>* layout = &pc_m->getLayout();
-        (*layout).updateLayout(*fl, *mesh);
+        pc_m->updateLayout(*fl, *mesh);
         IpplTimings::stopTimer(tupdateLayout);
         static IpplTimings::TimerRef tupdatePLayout = IpplTimings::getTimer("updatePB");
         IpplTimings::startTimer(tupdatePLayout);

--- a/src/PartBunch/PartBunch.cpp
+++ b/src/PartBunch/PartBunch.cpp
@@ -74,6 +74,11 @@ PartBunch<T, Dim>::PartBunch(
             OPALFieldSolver_m->getNX(), OPALFieldSolver_m->getNY(), OPALFieldSolver_m->getNZ());
     nrZBase_m = nr_m[Dim - 1];
 
+    const bool useP3M     = OPALFieldSolver_m->getFieldSolverCmdType() == FieldSolverCmdType::P3M;
+    const auto layoutType = useP3M ? ParticleContainer_t::LayoutType::SpatialOverlap
+                                   : ParticleContainer_t::LayoutType::Spatial;
+    const T p3mCutoff     = useP3M ? static_cast<T>(OPALFieldSolver_m->getP3MCutoff()) : T(0);
+
     const Vector_t<bool, 3> domainDecomposition = OPALFieldSolver_m->getDomainDecomposition();
 
     for (unsigned i = 0; i < Dim; i++) {
@@ -92,8 +97,14 @@ PartBunch<T, Dim>::PartBunch(
     //      domain is set
 
     Vector_t<double, Dim> length(6.0);
+    if (useP3M) {
+        // Keep the temporary overlap cell grid proportional to the requested cutoff.
+        for (unsigned d = 0; d < Dim; ++d) {
+            length[d] = static_cast<double>(nr_m[d]) * p3mCutoff;
+        }
+    }
     this->hr_m     = length / this->nr_m;
-    this->origin_m = -3.0;
+    this->origin_m = useP3M ? -0.5 * length : Vector_t<double, Dim>(-3.0);
     this->dt_m     = 0.5 / this->nr_m[2];
 
     rmin_m = origin_m;
@@ -106,14 +117,14 @@ PartBunch<T, Dim>::PartBunch(
     this->setParticleContainer(
             std::make_shared<ParticleContainer_t>(
                     this->fcontainer_m->getMesh(), this->fcontainer_m->getFL(),
-                    beams[0]->hasPolarization()));
+                    beams[0]->hasPolarization(), layoutType, p3mCutoff));
     this->pcontainer_m->setBunchStateHandler(bunchState_m);
     /// \todo if we want, we could also have a separate BunchStateHandler for each container later?
     /// But I think it could also make sense to only have one global handler.
     for (size_t i = 1; i < num_containers; ++i) {
         auto pc = std::make_shared<ParticleContainer_t>(
                 this->fcontainer_m->getMesh(), this->fcontainer_m->getFL(),
-                beams[i]->hasPolarization());
+                beams[i]->hasPolarization(), layoutType, p3mCutoff);
         pc->setBunchStateHandler(bunchState_m);
         this->addParticleContainer(pc);
     }
@@ -307,7 +318,7 @@ void PartBunch<T, Dim>::setSolver() {
             &this->fcontainer_m->getPhi(), this->getBCHandler(),
             binningCmd ? binningCmd->getTablePrintFrequency() : 0,
             binningCmd ? binningCmd->getAdaptiveBinning() : true,
-            OPALFieldSolver_m->getGreensFunction());
+            OPALFieldSolver_m->getGreensFunction(), OPALFieldSolver_m->getP3MCutoff());
     this->setFieldSolver(binnedSolver);
     m << level4 << "Binned field solver set (binned or legacy at runtime)." << endl;
 
@@ -765,7 +776,7 @@ void PartBunch<T, Dim>::applyGridUpdate(
         if (!pc) {
             continue;
         }
-        pc->getLayout().updateLayout(*FL, *mesh);
+        pc->updateLayout(*FL, *mesh);
         pc->update();
         pc->markMomentsDirty();  // IPPL migration may have re-indexed R across ranks
                                  /// \todo there might be a case where we can keep the moments clean
@@ -935,7 +946,7 @@ void PartBunch<T, Dim>::performBunchSanityChecks() const {
         throw OpalException(
                 "PartBunch::performBunchSanityChecks", "FieldSolver type string is empty.");
     }
-    if (stype != "FFT" && stype != "OPEN" && stype != "CG" && stype != "NONE") {
+    if (stype != "FFT" && stype != "P3M" && stype != "OPEN" && stype != "CG" && stype != "NONE") {
         throw OpalException(
                 "PartBunch::performBunchSanityChecks", "Unsupported FieldSolver type: " + stype);
     }

--- a/src/PartBunch/ParticleContainer.hpp
+++ b/src/PartBunch/ParticleContainer.hpp
@@ -27,6 +27,19 @@
 
 #include "Physics/Physics.h"
 
+// ParticleSpatialOverlapLayout.hpp currently includes IPPL's Alpine example ParticleContainer,
+// whose global class name collides with OPALX's container. The layout itself does not depend on
+// that example type, so suppress only that application header while including the IPPL layout.
+#ifndef IPPL_PARTICLE_CONTAINER_H
+#define OPALX_SUPPRESS_IPPL_ALPINE_PARTICLE_CONTAINER
+#define IPPL_PARTICLE_CONTAINER_H
+#endif
+#include "Particle/ParticleSpatialOverlapLayout.h"
+#ifdef OPALX_SUPPRESS_IPPL_ALPINE_PARTICLE_CONTAINER
+#undef IPPL_PARTICLE_CONTAINER_H
+#undef OPALX_SUPPRESS_IPPL_ALPINE_PARTICLE_CONTAINER
+#endif
+
 // #include <Kokkos_Core.hpp>
 
 template <typename T>
@@ -91,6 +104,11 @@ private:
     using Base::destroy;
 
 public:
+    using SpatialLayout_t = ippl::ParticleSpatialLayout<T, Dim, ippl::UniformCartesian<T, Dim>>;
+    using P3MLayout_t = ippl::ParticleSpatialOverlapLayout<T, Dim, ippl::UniformCartesian<T, Dim>>;
+
+    enum class LayoutType { Spatial, SpatialOverlap };
+
     enum class QMStorageMode { SingleValue, Attributes };
 
     /// Defines which type to use as a particle bin.
@@ -162,8 +180,16 @@ public:
     /// (enabled per beam when the BEAM has POLARIZATION set).
     bool hasSpin() const { return spinEnabled_m; }
 
-    ParticleContainer(Mesh_t<Dim>& mesh, FieldLayout_t<Dim>& FL, bool spinEnabled = false)
-        : pl_m(FL, mesh),
+    ParticleContainer(
+            Mesh_t<Dim>& mesh, FieldLayout_t<Dim>& FL, bool spinEnabled = false,
+            LayoutType layoutType = LayoutType::Spatial, T overlapCutoff = 0.0)
+        : spatialLayout_m(
+                  layoutType == LayoutType::Spatial ? std::make_unique<SpatialLayout_t>(FL, mesh)
+                                                    : nullptr),
+          overlapLayout_m(
+                  layoutType == LayoutType::SpatialOverlap
+                          ? std::make_unique<P3MLayout_t>(FL, mesh, overlapCutoff)
+                          : nullptr),
           qmStorageMode_m(
                   Options::useQMAttributes ? QMStorageMode::Attributes
                                            : QMStorageMode::SingleValue),
@@ -171,7 +197,7 @@ public:
           QView_m("ParticleContainer::QView_m", 1),
           MView_m("ParticleContainer::MView_m", 1),
           spinEnabled_m(spinEnabled) {
-        this->initialize(pl_m);
+        this->initialize(getPL());
         registerAttributes();
         setupBCs();
         Kokkos::deep_copy(QView_m, 0.0);
@@ -198,7 +224,7 @@ public:
         }
     }
 
-    void setupBCs() { setBCAllPeriodic(); }
+    void setupBCs() { this->setParticleBC(ippl::BC::PERIODIC); }
 
     /// Apply coordinate transform to local particles: translate R, rotate P, E, B.
     void transformBunch(const CoordinateSystemTrafo& trafo) {
@@ -209,7 +235,50 @@ public:
         trafo.rotateBunchTo(this->B.getView(), nLoc);
         markMomentsDirty();
     }
-    PLayout_t<T, Dim>& getPL() { return pl_m; }
+    SpatialLayout_t& getPL() {
+        return overlapLayout_m ? static_cast<SpatialLayout_t&>(*overlapLayout_m) : *spatialLayout_m;
+    }
+
+    const SpatialLayout_t& getPL() const {
+        return overlapLayout_m ? static_cast<const SpatialLayout_t&>(*overlapLayout_m)
+                               : *spatialLayout_m;
+    }
+
+    bool hasP3MLayout() const { return overlapLayout_m != nullptr; }
+
+    P3MLayout_t& getP3MLayout() {
+        if (!overlapLayout_m) {
+            throw OpalException(
+                    "ParticleContainer::getP3MLayout",
+                    "The particle container does not use ParticleSpatialOverlapLayout.");
+        }
+        return *overlapLayout_m;
+    }
+
+    const P3MLayout_t& getP3MLayout() const {
+        if (!overlapLayout_m) {
+            throw OpalException(
+                    "ParticleContainer::getP3MLayout",
+                    "The particle container does not use ParticleSpatialOverlapLayout.");
+        }
+        return *overlapLayout_m;
+    }
+
+    void updateLayout(FieldLayout_t<Dim>& FL, Mesh_t<Dim>& mesh) {
+        if (overlapLayout_m) {
+            overlapLayout_m->updateLayout(FL, mesh);
+        } else {
+            spatialLayout_m->updateLayout(FL, mesh);
+        }
+    }
+
+    void update() {
+        if (overlapLayout_m) {
+            overlapLayout_m->update(*this);
+        } else {
+            spatialLayout_m->update(*this);
+        }
+    }
 
     void setBunchStateHandler(std::shared_ptr<BunchStateHandler> handler) {
         // We only keep the slot: per-container flags own their own sync, so
@@ -884,9 +953,8 @@ public:
     }
 
 private:
-    void setBCAllPeriodic() { this->setParticleBC(ippl::BC::PERIODIC); }
-
-    PLayout_t<T, Dim> pl_m;
+    std::unique_ptr<SpatialLayout_t> spatialLayout_m;
+    std::unique_ptr<P3MLayout_t> overlapLayout_m;
 
     QMStorageMode qmStorageMode_m = QMStorageMode::SingleValue;
 

--- a/src/Structure/FieldSolverCmd.cpp
+++ b/src/Structure/FieldSolverCmd.cpp
@@ -41,8 +41,7 @@ FieldSolverCmd::FieldSolverCmd()
               FIELDSOLVER::SIZE, "FIELDSOLVER",
               "The \"FIELDSOLVER\" statement defines data for a the field solver") {
     itsAttr[FIELDSOLVER::TYPE] = Attributes::makePredefinedString(
-            "TYPE", "Name of the attached field solver.",
-            {"NONE", "FFT", "OPEN", "CG"});  // removed, since not implemented: "P3M"
+            "TYPE", "Name of the attached field solver.", {"NONE", "FFT", "P3M", "OPEN", "CG"});
 
     itsAttr[FIELDSOLVER::BINS] = Attributes::makeString(
             "BINS", "Name of BINNING definition to be used, or NONE for no binning.", "NONE");
@@ -73,6 +72,9 @@ FieldSolverCmd::FieldSolverCmd()
             "GREENSF", "Which Greensfunction to be used.", {"STANDARD", "INTEGRATED"},
             "INTEGRATED");
 
+    itsAttr[FIELDSOLVER::P3MRCUT] = Attributes::makeReal(
+            "RCUT", "P3M particle-particle cutoff radius in m (ALPHA is derived as 2/RCUT).", 0.0);
+
     itsAttr[FIELDSOLVER::BBOXINCR] =
             Attributes::makeReal("BBOXINCR", "Increase of bounding box in % ", 2.0);
 
@@ -90,6 +92,7 @@ FieldSolverCmd* FieldSolverCmd::clone(const std::string& name) {
 
 void FieldSolverCmd::execute() {
     setFieldSolverCmdType();
+    validateP3MConfiguration();
     setDomainDecomposition();
     update();
 }
@@ -113,6 +116,10 @@ std::string FieldSolverCmd::getGreensFunction() const {
     return Attributes::getString(itsAttr[FIELDSOLVER::GREENSF]);
 }
 
+double FieldSolverCmd::getP3MCutoff() const {
+    return Attributes::getReal(itsAttr[FIELDSOLVER::P3MRCUT]);
+}
+
 BCHandler<3> FieldSolverCmd::constructBCHandler() const {
     using BCH_t = BCHandler<3>;
 
@@ -132,6 +139,13 @@ BCHandler<3> FieldSolverCmd::constructBCHandler() const {
                 "Currently only uniform boundary conditions in all "
                 "dimensions are supported! Please set all "
                 "dimensions to either OPEN or PERIODIC.");
+    }
+
+    if (Attributes::getString(itsAttr[FIELDSOLVER::TYPE]) == "P3M"
+        && !boundary_conditions.isAll(BCH_t::PERIODIC)) {
+        throw OpalException(
+                "FieldSolverCmd::constructBCHandler",
+                "TYPE=P3M requires PERIODIC boundary conditions in all dimensions.");
     }
 
     return boundary_conditions;
@@ -163,6 +177,7 @@ void FieldSolverCmd::setFieldSolverCmdType() {
     static const std::map<std::string, FieldSolverCmdType> stringType_s = {
             {"NONE", FieldSolverCmdType::NONE},
             {"FFT", FieldSolverCmdType::FFT},
+            {"P3M", FieldSolverCmdType::P3M},
             {"OPEN", FieldSolverCmdType::OPEN},
             {"CG", FieldSolverCmdType::CG}};
 
@@ -174,6 +189,25 @@ void FieldSolverCmd::setFieldSolverCmdType() {
                 "The attribute \"TYPE\" isn't set for \"FIELDSOLVER\"!");
     } else {
         fsType_m = stringType_s.at(fsName_m);
+    }
+}
+
+void FieldSolverCmd::validateP3MConfiguration() const {
+    if (fsType_m != FieldSolverCmdType::P3M) {
+        return;
+    }
+
+    if (getP3MCutoff() <= 0.0) {
+        throw OpalException(
+                "FieldSolverCmd::validateP3MConfiguration",
+                "TYPE=P3M requires RCUT to be greater than zero.");
+    }
+
+    const std::string binsName = getBinsName();
+    if (!binsName.empty() && binsName != "NONE") {
+        throw OpalException(
+                "FieldSolverCmd::validateP3MConfiguration",
+                "TYPE=P3M does not support BINS. Remove BINS from the FIELDSOLVER definition.");
     }
 }
 
@@ -215,6 +249,12 @@ Inform& FieldSolverCmd::printInfo(Inform& os) const {
        << "* NZ           " << Attributes::getReal(itsAttr[FIELDSOLVER::NZ]) << '\n'
        << "* BBOXINCR     " << Attributes::getReal(itsAttr[FIELDSOLVER::BBOXINCR]) << '\n'
        << "* GREENSF      " << Attributes::getString(itsAttr[FIELDSOLVER::GREENSF]) << endl;
+
+    if (fsName_m == "P3M") {
+        const double cutoff = getP3MCutoff();
+        os << "* RCUT         " << cutoff << " [m]" << '\n'
+           << "* ALPHA        " << 2.0 / cutoff << " [1/m]" << endl;
+    }
 
     if (Attributes::getBool(itsAttr[FIELDSOLVER::PARFFTX])) {
         os << "* XDIM         parallel  " << endl;

--- a/src/Structure/FieldSolverCmd.h
+++ b/src/Structure/FieldSolverCmd.h
@@ -30,7 +30,7 @@
 
 #include "Ippl.h"
 
-enum class FieldSolverCmdType : short { NONE = -1, FFT = 0, OPEN = 1, CG = 2 };
+enum class FieldSolverCmdType : short { NONE = -1, FFT = 0, OPEN = 1, CG = 2, P3M = 3 };
 
 // The attributes of class FieldSolverCmd.
 namespace FIELDSOLVER {
@@ -47,6 +47,7 @@ namespace FIELDSOLVER {
         BCFFTY,    // boundary condition in y [FFT + AMR_MG only]
         BCFFTZ,    // boundary condition in z [FFT + AMR_MG only]
         GREENSF,   // holds greensfunction to be used [FFT + P3M only]
+        P3MRCUT,   // P3M particle-particle cutoff radius [m]
         BBOXINCR,  // how much the boundingbox is increased
         SIZE
     };
@@ -69,6 +70,7 @@ public:
     std::string getBinsName() const;
     BinningCmd* getBinningCmd() const;
     std::string getGreensFunction() const;
+    double getP3MCutoff() const;
 
     /// Returns solver boundary conditions handler object.
     BCHandler<3> constructBCHandler() const;
@@ -117,6 +119,8 @@ private:
 
     // Clone constructor.
     FieldSolverCmd(const std::string& name, FieldSolverCmd* parent);
+
+    void validateP3MConfiguration() const;
 
     std::string fsName_m;
     FieldSolverCmdType fsType_m;

--- a/src/ValueDefinitions/StringConstant.cpp
+++ b/src/ValueDefinitions/StringConstant.cpp
@@ -135,6 +135,7 @@ StringConstant::StringConstant()
 
     // FieldSolver / FSTYPE
     CREATE_STRINGCONSTANT("FFT");
+    CREATE_STRINGCONSTANT("P3M");
     /// \todo find a better way to say open solver! (Issue #158)
     // CREATE_STRINGCONSTANT("OPEN"); // already exists as BC!
     CREATE_STRINGCONSTANT("CG");


### PR DESCRIPTION
closes #489 

After IPPL-framework/ippl#578 is merged, I can now also make the corresponding OPALX PR. Additionally, I'll add a regression test, see OPALX-project/regression-tests-x#52. 

Feel free to read [this comment](https://github.com/OPALX-project/OPALX/issues/489#issuecomment-5057540920) for the changes I made on the IPPL side. The comment also has an example plot where a P3M drift (very similar to the regression test mentioned above) is compared to the periodic FFT solver.


## Changes

- **Add `P3M` as a runtime-selectable field solver.** OPALX derives $\alpha=2/r_{\mathrm{cut}}$ and reports both values. The parser also requires fully periodic boundary conditions and rejects `BINS`, since this first implementation supports only periodic, whole-bunch P3M.

- **Select the particle layout at runtime.** `ParticleContainer` now owns either the existing `ParticleSpatialLayout` or IPPL’s `ParticleSpatialOverlapLayout`, with P3M selecting the overlap layout using `RCUT`. _The overlap layout is required to construct periodic ghost particles and neighbor-cell data for short-range interactions without duplicating IPPL’s neighbor search._

- **Route layout updates through the active layout implementation.** Particle migration, grid resizing, distribution initialization, and load balancing now call `ParticleContainer::update()` and `updateLayout()` rather than directly accessing the spatial layout. This keeps existing solvers unchanged while ensuring that P3M rebuilds its overlap cells and ghost-particle information whenever the mesh or decomposition changes. **This needs to be optimized later, since it now rebuilds the neighbor list way more often than necessary!!**

- **Initialize a valid provisional domain for the overlap layout.** Before the sampled bunch dimensions are known, the temporary P3M domain is sized so that its initial mesh spacing is proportional to `RCUT`. This prevents construction of an invalid or excessively large overlap-cell grid during early bunch initialization.

- **Add the short-range particle-particle correction.** After gathering the mesh field, OPALX calls IPPL’s `TruncatedGreenParticleInteraction` with `RCUT`, $\alpha$, particle positions, and macrocharges. Small adapter views expose OPALX’s active overlap layout and charge-storage modes to IPPL, allowing the existing GPU-compatible pair iteration and neighbor search to be reused. This is separated from the `FFTTruncatedGreensFunction` solve step.

- `regularization_cutoff` is currently hardcoded to `sp.add("regularization_cutoff", 1.0e-9);`. I will probably (later) allow this parameter to be changed through the input file.

Here a call diagram how the self field call structure for P3M now looks:

```mermaid
flowchart TD
    A["ParallelTracker: computeSpaceChargeFields"] --> B["Transform particles to beam frame"]
    B --> C["Fit mesh to the bunch"]
    C --> D("Exchange overlap particles")
    D --> E("Create periodic copies and cell lists")
    E --> F["PartBunch: computeSelfFields"]
    F --> G["Scatter charge to rho"]
    G --> H("Forward real-to-complex FFT")
    H --> I("Apply analytic long-range operator")
    I --> J("Compute three spectral gradients")
    J --> K["Gather mesh field to particle E"]
    K --> L("Traverse neighbor-cell pairs")
    L --> M{"0 < r_ij < r_c"}
    M -->|yes| N("Add regularized erfc field to particle E")
    M -->|no| O["Skip pair"]
    N --> P["Final P3M particle field"]
    O --> P
    P --> Q["Return to reference frame and rebuild layout"]
```

Additionally, we can look at the spatial layout selection, since this has consequences on how the update routine is called:

```mermaid
flowchart TD
    A{"Solver type"} -->|P3M| B["overlapLayout_m owns SpatialOverlap"]
    A -->|other| C["spatialLayout_m owns SpatialLayout"]
    B --> D["getPL returns SpatialLayout reference"]
    C --> D
    D --> E["ParticleBase type stays unchanged"]
    B --> F["update dispatch"]
    F --> G["Exchange overlap particles"]
    G --> H["Build local and ghost cell lists"]
    H --> I["Device neighbor-pair traversal"]
```

## Testing

All unit and regression tests pass multirank on GPU (GH200, Daint) as well as on CPU (local Mac), including the new `Drift-3-p3m-periodic-fromfile`. 