### PR TITLE
Aperture Implementation Part 1 - Change `apply()` Return Type

### DIFF
--- a/src/AbsBeamline/ConstantEFieldCavity.cpp
+++ b/src/AbsBeamline/ConstantEFieldCavity.cpp
@@ -40,7 +40,7 @@ void ConstantEFieldCavity::setEy(double ey) { Ey_m = ey; }
 
 void ConstantEFieldCavity::setEz(double ez) { Ez_m = ez; }
 
-bool ConstantEFieldCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void ConstantEFieldCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     auto Rview          = pc->R.getView();
     auto Eview          = pc->E.getView();
     const size_t nLocal = pc->getLocalNum();
@@ -58,26 +58,28 @@ bool ConstantEFieldCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc)
                     Eview(i)[2] += Ez;
                 }
             });
-    return false;
 }
 
-bool ConstantEFieldCavity::apply(
+void ConstantEFieldCavity::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& E, Vector_t<double, 3>& /*B*/) {
-    if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return false;
-    if (!isInsideTransverse(R)) return getFlagDeleteOnTransverseExit();
+    if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return;
+    if (!isInsideTransverse(R)) {
+        return;
+    }
 
     E(0) += Ex_m;
     E(1) += Ey_m;
     E(2) += Ez_m;
-    return false;
 }
 
 bool ConstantEFieldCavity::applyToReferenceParticle(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& E, Vector_t<double, 3>& /*B*/) {
     if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return false;
-    if (!isInsideTransverse(R)) return true;
+    if (!isInsideTransverse(R)) {
+        return true;
+    }
 
     E(0) += Ex_m;
     E(1) += Ey_m;

--- a/src/AbsBeamline/ConstantEFieldCavity.h
+++ b/src/AbsBeamline/ConstantEFieldCavity.h
@@ -24,9 +24,9 @@ public:
     virtual ElementType getType() const override;
     virtual void getFieldExtent(double& zBegin, double& zEnd) const override;
 
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
     virtual bool applyToReferenceParticle(

--- a/src/AbsBeamline/Corrector.cpp
+++ b/src/AbsBeamline/Corrector.cpp
@@ -52,19 +52,21 @@ Corrector::~Corrector() {}
 
 void Corrector::accept(BeamlineVisitor& visitor) const { visitor.visitCorrector(*this); }
 
-bool Corrector::apply(
+void Corrector::apply(
         const size_t& i, const double& t, Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     Vector_t<double, 3>& R = RefPartBunch_m->R[i];
     Vector_t<double, 3>& P = RefPartBunch_m->P[i];
 
-    return apply(R, P, t, E, B);
+    apply(R, P, t, E, B);
 }
 
-bool Corrector::apply(
+void Corrector::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& B) {
     if (R(2) >= 0.0 && R(2) < getElementLength()) {
-        if (!isInsideTransverse(R)) return getFlagDeleteOnTransverseExit();
+        if (!isInsideTransverse(R)) {
+            return;
+        }
 
         double tau            = 1.0;
         const double& dt      = RefPartBunch_m->getdT();
@@ -79,8 +81,6 @@ bool Corrector::apply(
 
         B += kickField_m * tau;
     }
-
-    return false;
 }
 
 void Corrector::initialise(PartBunch_t* bunch) { RefPartBunch_m = bunch; }

--- a/src/AbsBeamline/Corrector.h
+++ b/src/AbsBeamline/Corrector.h
@@ -57,12 +57,12 @@ public:
     /// Return the plane on which the corrector acts.
     virtual Plane getPlane() const = 0;
 
-    virtual bool apply(
+    virtual void apply(
             const size_t& i, const double& t, Vector_t<double, 3>& E, Vector_t<double, 3>& B);
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
-            Vector_t<double, 3>& E, Vector_t<double, 3>& B);
+            Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 
     virtual void initialise(PartBunch_t* bunch);
 

--- a/src/AbsBeamline/ElementBase.cpp
+++ b/src/AbsBeamline/ElementBase.cpp
@@ -224,15 +224,13 @@ void ElementBase::goOnline(const double&) { online_m = true; }
 
 void ElementBase::goOffline() { online_m = false; }
 
-bool ElementBase::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) { return false; }
+void ElementBase::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) {}
 
-bool ElementBase::apply(
-        const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
+void ElementBase::apply(
+        const Vector_t<double, 3>& /*R*/, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& /*B*/) {
-    if (R(2) >= 0.0 && R(2) < getGeometry().getElementLength()) {
-        if (!isInsideTransverse(R)) return true;
-    }
-    return false;
+    // A bare element carries no field. The bounds/aperture test the previous
+    // bool overload performed here only produced the (unused) return value.
 }
 
 bool ElementBase::applyToReferenceParticle(

--- a/src/AbsBeamline/ElementBase.h
+++ b/src/AbsBeamline/ElementBase.h
@@ -231,23 +231,22 @@ public:
 
     /**
      * @brief Apply to all particles. Kernel launch moved inside the function.
-     *
-     * @returns true if particle is out-of-bounds (lost), false otherwise
      */
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc);
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc);
 
     /**
      * @brief Apply to particle with position R and momentum P
+     *
+     * Fields are only applied to particles inside the element's field bounds
+     * and transverse aperture.
      *
      * @param R Position
      * @param P Momentum
      * @param t Time
      * @param E Electric Field
      * @param B Magnetic Field
-     *
-     * @returns true if particle is out-of-bounds (lost), false otherwise
      */
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B);
 

--- a/src/AbsBeamline/Monitor.cpp
+++ b/src/AbsBeamline/Monitor.cpp
@@ -137,7 +137,6 @@ void Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
             }
         }
     }
-
 }
 
 void Monitor::apply(

--- a/src/AbsBeamline/Monitor.cpp
+++ b/src/AbsBeamline/Monitor.cpp
@@ -55,13 +55,13 @@ Monitor::~Monitor() {}
 
 void Monitor::accept(BeamlineVisitor& visitor) const { visitor.visitMonitor(*this); }
 
-bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     if (!online_m || lossDs_m == nullptr || pc == nullptr || RefPartBunch_m == nullptr) {
-        return false;
+        return;
     }
 
     if (type_m != CollectionType::SPATIAL) {
-        return false;
+        return;
     }
 
     const long long globalStep = RefPartBunch_m->getGlobalTrackStep();
@@ -71,12 +71,12 @@ bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
         Inform msg("Monitor::apply(pc)");
         msg << level5 << "Ignoring pre-tracking spatial particle crossing"
             << " globalStep=" << globalStep << " pc_spos=" << sPos << endl;
-        return false;
+        return;
     }
 
     const auto nLoc = pc->getLocalNum();
     if (nLoc == 0) {
-        return false;
+        return;
     }
 
     auto Rview  = pc->R.getView();
@@ -138,16 +138,14 @@ bool Monitor::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
         }
     }
 
-    return false;
 }
 
-bool Monitor::apply(
+void Monitor::apply(
         const Vector_t<double, 3>& /*R*/, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& /*B*/) {
     // Monitor is field-free.
     // This overload does not provide particle ID and may not provide the correct
     // per-particle dt/q/m information, so it cannot safely save monitor hits.
-    return false;
 }
 
 void Monitor::driftToCorrectPositionAndSave(

--- a/src/AbsBeamline/Monitor.h
+++ b/src/AbsBeamline/Monitor.h
@@ -56,9 +56,9 @@ public:
     /// Get plane on which monitor observes.
     virtual Plane getPlane() const = 0;
 
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/Multipole.cpp
+++ b/src/AbsBeamline/Multipole.cpp
@@ -237,12 +237,8 @@ void Multipole::setSkewComponent(int n, double v, double vError) {
  * @brief Applies the multipole field to all particles inside the magnet bounds
  *
  * @note The kernel launch is moved inside this functions for GPU compatibility
- *
- * @note TODO: Out-of-bounds check
- *
- * @returns true if particle is out-of-bounds (lost), false otherwise
  */
-bool Multipole::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void Multipole::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     *gmsg << level3 << "Multipole::apply() called" << endl;
     // Get the views
     auto Rview          = pc->R.getView();
@@ -274,19 +270,8 @@ bool Multipole::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
                     }
                 }
             });
-    return false;
 }
 
-/**
- * @brief Applies the multipole field at particle i's position to E and B
- *
- * @note Cannot be inside a kernel -> GPU incompatible
- *
- * @param i Particle index
- * @param E Electric field reference
- * @param B Magnetic field reference
- * @returns true if particle is out-of-bounds (lost), false otherwise
- */
 /**
  * @brief Applies the multipole field at position R to E and B
  *
@@ -295,20 +280,18 @@ bool Multipole::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
  * @param R Position
  * @param E Electric field reference
  * @param B Magnetic field reference
- * @returns true if particle is out-of-bounds (lost), false otherwise
  */
-
-bool Multipole::apply(
+void Multipole::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>&, const double&,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     // Check bounds
-    if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return false;
-    if (!isInsideTransverse(R)) return getFlagDeleteOnTransverseExit();
+    if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return;
+    if (!isInsideTransverse(R)) {
+        return;
+    }
 
     // Compute field
     computeFieldHost(R, E, B);
-
-    return false;
 }
 
 /**
@@ -327,7 +310,9 @@ bool Multipole::applyToReferenceParticle(
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     // Check bounds
     if (R(2) < 0.0 || R(2) > getGeometry().getElementLength()) return false;
-    if (!isInsideTransverse(R)) return true;
+    if (!isInsideTransverse(R)) {
+        return true;
+    }
 
     /*
     for (int i = 0; i < max_NormalComponent_m; ++i) {

--- a/src/AbsBeamline/Multipole.h
+++ b/src/AbsBeamline/Multipole.h
@@ -63,21 +63,9 @@ public:
     /* ============================== Apply Functions =========================== */
     /**
      * @brief Apply to all particles. Kernel launch moved inside the function.
-     *
-     * @returns true if particle is out-of-bounds (lost), false otherwise
      */
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    /**
-     * @brief Apply to particle i
-     *
-     * @param i Particle index
-     * @param t Time
-     * @param E Electric Field
-     * @param B Magnetic Field
-     *
-     * @returns true if particle is out-of-bounds (lost), false otherwise
-     */
     /**
      * @brief Apply to particle with position R and momentum P
      *
@@ -86,10 +74,8 @@ public:
      * @param t Time
      * @param E Electric Field
      * @param B Magnetic Field
-     *
-     * @returns true if particle is out-of-bounds (lost), false otherwise
      */
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/MultipoleT.cpp
+++ b/src/AbsBeamline/MultipoleT.cpp
@@ -46,19 +46,18 @@ double MultipoleT::getScaling(const double t) const {
     return scaling;
 }
 
-bool MultipoleT::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void MultipoleT::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     validateConfiguration();
     implementation_->getField(
             pc->R.getView(), pc->E.getView(), pc->B.getView(), getScaling(RefPartBunch_m->getT()),
             pc->getLocalNum());
-    return false;
 }
 
-bool MultipoleT::apply(
+void MultipoleT::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& t,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     validateConfiguration();
-    return implementation_->getField(R, E, B, getScaling(t));
+    implementation_->getField(R, E, B, getScaling(t));
 }
 
 void MultipoleT::setFringeField(

--- a/src/AbsBeamline/MultipoleT.h
+++ b/src/AbsBeamline/MultipoleT.h
@@ -87,17 +87,15 @@ public:
     /** Return the cell geometry */
     const Geometry& getGeometry() const override;
     /** Calculate the field for all particles */
-    bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
     /** Calculate the field at some arbitrary position \n
-     *  If particle is outside field map true is returned,
-     *  otherwise false is returned
      *  \param R -> Position in the lab coordinate system of the multipole
      *  \param P -> Not used
      *  \param t -> Time at which the field is to be calculated
      *  \param E -> Calculated electric field - always 0 (no E-field)
      *  \param B -> Calculated magnetic field
      */
-    bool apply(
+    void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
     /** Calculate the field at the position of the ith particle
@@ -105,8 +103,6 @@ public:
      *  position
      *  This overload is single-container only. In multi-container tracking,
      *  use apply(const std::shared_ptr<ParticleContainer_t>& pc).
-     *  If particle is outside field map true is returned,
-     *  otherwise false is returned
      *  \param t -> Time at which the field is to be calculated
      *  \param E -> Calculated electric field - always 0 (no E-field)
      *  \param B -> Calculated magnetic field

--- a/src/AbsBeamline/PluginElement.cpp
+++ b/src/AbsBeamline/PluginElement.cpp
@@ -60,13 +60,12 @@ void PluginElement::goOffline() {
     online_m = false;
 }
 
-bool PluginElement::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) { return false; }
+void PluginElement::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) {}
 
-bool PluginElement::apply(
+void PluginElement::apply(
         const Vector_t<double, 3>& /*R*/, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& /*B*/) {
     *gmsg << "passed R, P, t, E, B arguments not used in PluginElement::apply" << endl;
-    return false;
 }
 
 bool PluginElement::applyToReferenceParticle(

--- a/src/AbsBeamline/PluginElement.h
+++ b/src/AbsBeamline/PluginElement.h
@@ -50,9 +50,9 @@ public:
     virtual bool isInside(const Vector_t<double, 3>& r) const override;
     ///@}
     ///@{ Virtual implementation of Component
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/RBend.cpp
+++ b/src/AbsBeamline/RBend.cpp
@@ -36,7 +36,7 @@ void RBend::initialise(PartBunch_t* bunch) {
 
 void RBend::finalise() { online_m = false; }
 
-bool RBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void RBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     auto Rview          = pc->R.getView();
     auto Bview          = pc->B.getView();
     const size_t nLocal = pc->getLocalNum();
@@ -62,25 +62,22 @@ bool RBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
                 Bview(i)(1) += Bf(1);
                 Bview(i)(2) += Bf(2);
             });
-
-    return false;
 }
 
-bool RBend::apply(
+void RBend::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>&, const double&,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     double zBegin = 0.0, zEnd = 0.0;
     getFieldExtent(zBegin, zEnd);
     if (R(2) < zBegin || R(2) >= zEnd) {
-        return false;
+        return;
     }
     if (!isInsideTransverse(R)) {
-        return getFlagDeleteOnTransverseExit();
+        return;
     }
 
     computeFieldHost(R, B);
     (void)E;
-    return false;
 }
 
 bool RBend::applyToReferenceParticle(

--- a/src/AbsBeamline/RBend.h
+++ b/src/AbsBeamline/RBend.h
@@ -48,8 +48,7 @@ public:
 
     /// @brief Apply the field to all particles.
     /// @param pc The particle container.
-    /// @return True if a particle is out-of-bounds (lost), false otherwise.
-    bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
     /// @brief Apply the field to a particle with position R and momentum P.
     /// @param R Position.
@@ -57,8 +56,7 @@ public:
     /// @param t Time.
     /// @param E Electric field.
     /// @param B Magnetic field.
-    /// @return True if the particle is out-of-bounds (lost), false otherwise.
-    bool apply(
+    void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/RFCavity.cpp
+++ b/src/AbsBeamline/RFCavity.cpp
@@ -115,7 +115,7 @@ void RFCavity::accept(BeamlineVisitor& visitor) const { visitor.visitRFCavity(*t
  * @note TODO: Check if getFieldstrength(R, tmpE, tmpB) returns 0 outside of RF cavity to skip if
  * statement
  */
-bool RFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void RFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     // RF parameters (copied to device)
     double freq  = frequency_m;
     double scale = scale_m + scaleError_m;
@@ -146,23 +146,20 @@ bool RFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
                 "RFCavity particle application currently requires an FM2DDynamic or Astra1DDynamic "
                 "field map.");
     }
-
-    return false;
 }
 
-bool RFCavity::apply(
+void RFCavity::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& t,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     if (R(2) >= startField_m && R(2) < endField_m) {
         Vector_t<double, 3> tmpE({0.0, 0.0, 0.0}), tmpB({0.0, 0.0, 0.0});
 
         bool outOfBounds = fieldmap_m->getFieldstrength(R, tmpE, tmpB);
-        if (outOfBounds) return getFlagDeleteOnTransverseExit();
+        if (outOfBounds) return;
 
         E += (scale_m + scaleError_m) * std::cos(frequency_m * t + phase_m + phaseError_m) * tmpE;
         B -= (scale_m + scaleError_m) * std::sin(frequency_m * t + phase_m + phaseError_m) * tmpB;
     }
-    return false;
 }
 
 bool RFCavity::applyToReferenceParticle(

--- a/src/AbsBeamline/RFCavity.h
+++ b/src/AbsBeamline/RFCavity.h
@@ -93,9 +93,9 @@ public:
             const double& p0, const double& t0, const double& dt, const double& q,
             const double& mass, std::ofstream* out = nullptr);
 
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/SBend.cpp
+++ b/src/AbsBeamline/SBend.cpp
@@ -43,7 +43,7 @@ void SBend::initialise(PartBunch_t* bunch) {
 
 void SBend::finalise() { online_m = false; }
 
-bool SBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void SBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     auto Rview          = pc->R.getView();
     auto Bview          = pc->B.getView();
     const size_t nLocal = pc->getLocalNum();
@@ -77,24 +77,21 @@ bool SBend::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
                 Bview(i)(1) += Bf(1);
                 Bview(i)(2) += Bf(2);
             });
-
-    return false;
 }
 
-bool SBend::apply(
+void SBend::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>&, const double&,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     const Vector_t<double, 3> arc = bendCoords(R);
     if (!isInsideArc(arc)) {
-        return false;
+        return;
     }
     if (!isInsideTransverse(arc)) {
-        return getFlagDeleteOnTransverseExit();
+        return;
     }
 
     computeFieldHost(R, B);
     (void)E;
-    return false;
 }
 
 bool SBend::applyToReferenceParticle(

--- a/src/AbsBeamline/SBend.h
+++ b/src/AbsBeamline/SBend.h
@@ -51,8 +51,7 @@ public:
 
     /// @brief Apply the field to all particles.
     /// @param pc The particle container.
-    /// @return True if a particle is out-of-bounds (lost), false otherwise.
-    bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
     /// @brief Apply the field to a particle with position R and momentum P.
     /// @param R Position.
@@ -60,8 +59,7 @@ public:
     /// @param t Time.
     /// @param E Electric field.
     /// @param B Magnetic field.
-    /// @return True if the particle is out-of-bounds (lost), false otherwise.
-    bool apply(
+    void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/ScalingFFAMagnet.cpp
+++ b/src/AbsBeamline/ScalingFFAMagnet.cpp
@@ -65,7 +65,7 @@ ScalingFFAMagnet* ScalingFFAMagnet::clone() const {
     return magnet;
 }
 
-bool ScalingFFAMagnet::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) { return false; }
+void ScalingFFAMagnet::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) {}
 
 void ScalingFFAMagnet::initialise() { calculateDfCoefficients(); }
 
@@ -148,10 +148,10 @@ bool ScalingFFAMagnet::getFieldValueCylindrical(
     return false;
 }
 
-bool ScalingFFAMagnet::apply(
+void ScalingFFAMagnet::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& B) {
-    return getFieldValue(R, B);
+    getFieldValue(R, B);
 }
 
 void ScalingFFAMagnet::calculateDfCoefficients() {

--- a/src/AbsBeamline/ScalingFFAMagnet.h
+++ b/src/AbsBeamline/ScalingFFAMagnet.h
@@ -64,9 +64,8 @@ public:
      *  \param t time at which the field is to be calculated
      *  \param E calculated electric field - always 0 (no E-field)
      *  \param B calculated magnetic field
-     *  \returns true if particle is outside the field map
      */
-    bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
     /** Calculate the field at some arbitrary position
      *
@@ -75,9 +74,8 @@ public:
      *  \param t not used
      *  \param E not used
      *  \param B calculated magnetic field
-     *  \returns true if particle is outside the field map, else false
      */
-    bool apply(
+    void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/Solenoid.cpp
+++ b/src/AbsBeamline/Solenoid.cpp
@@ -64,25 +64,13 @@ Solenoid::~Solenoid() {
  * @returns true if at least one particle is lost, false otherwise
  * (not implemented, always returns false)
  */
-bool Solenoid::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void Solenoid::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     Inform m("Solenoid::apply");
     m << level5 << "Solenoid::apply() called." << endl;
 
     fieldmap_m->applyField(pc, scale_m + scaleError_m);
-
-    return false;
 }
 
-/**
- * @brief apply the solenoid field to particle i
- *
- * @param i Particle index
- * @param t Time
- * @param E Electric Field
- * @param B Magnetic Field
- *
- * @returns true if particle is lost, false otherwise
- */
 /**
  * @brief Apply to particle with position R and momentum P
  *
@@ -91,10 +79,8 @@ bool Solenoid::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
  * @param t Time
  * @param E Electric Field
  * @param B Magnetic Field
- *
- * @returns true if particle is lost, false otherwise
  */
-bool Solenoid::apply(
+void Solenoid::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& B) {
     if (R(2) >= startField_m && R(2) < endField_m) {
@@ -102,13 +88,11 @@ bool Solenoid::apply(
 
         const bool outOfBounds = fieldmap_m->getFieldstrength(R, tmpE, tmpB);
         if (outOfBounds) {
-            return getFlagDeleteOnTransverseExit();
+            return;
         }
 
         B += (scale_m + scaleError_m) * tmpB;
     }
-
-    return false;
 }
 
 /**

--- a/src/AbsBeamline/Solenoid.h
+++ b/src/AbsBeamline/Solenoid.h
@@ -42,9 +42,8 @@ public:
     /**
      * @brief apply the solenoid field to all particles in the bunch
      *
-     * @returns true if at least one particle is lost, false otherwise
      */
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
     /**
      * @brief apply the solenoid field to particle i
@@ -65,9 +64,8 @@ public:
      * @param E Electric Field
      * @param B Magnetic Field
      *
-     * @returns true if particle is lost, false otherwise
      */
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/TravelingWave.cpp
+++ b/src/AbsBeamline/TravelingWave.cpp
@@ -63,7 +63,7 @@ void TravelingWave::accept(BeamlineVisitor& visitor) const { visitor.visitTravel
  * of the field from the core to the exit region, while maintaining the correct phase
  * relationship between the fields.
  */
-bool TravelingWave::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void TravelingWave::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     // RF parameters (copied to device)
     const double freq       = frequency_m;
     const double scaleEntry = scale_m + scaleError_m;
@@ -107,22 +107,20 @@ bool TravelingWave::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
             -scaleCore * sinCore1, scaleCore * cosCore2, -scaleCore * sinCore2,
             scaleEntry * cosExit, -scaleEntry * sinExit, startField, startCoreField, startExitField,
             mappedStartExit, periodLength, cellLength, fieldLength);
-
-    return false;
 }
 
-bool TravelingWave::apply(
+void TravelingWave::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& t,
         Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     const double omega_t = frequency_m * t;
-    if (R(2) < startField_m || R(2) >= endField_m) return false;
+    if (R(2) < startField_m || R(2) >= endField_m) return;
 
     Vector_t<double, 3> tmpR({R(0), R(1), R(2) - startField_m});
     Vector_t<double, 3> tmpE({0.0, 0.0, 0.0}), tmpB({0.0, 0.0, 0.0});
     double tmpcos = 0.0, tmpsin = 0.0;
 
     if (tmpR(2) < startCoreField_m) {
-        if (!fieldmap_m->isInside(tmpR)) return getFlagDeleteOnTransverseExit();
+        if (!fieldmap_m->isInside(tmpR)) return;
 
         tmpcos = (scale_m + scaleError_m) * std::cos(omega_t + phase_m + phaseError_m);
         tmpsin = -(scale_m + scaleError_m) * std::sin(omega_t + phase_m + phaseError_m);
@@ -133,7 +131,7 @@ bool TravelingWave::apply(
         tmpR(2)        = tmpR(2) - periodLength_m * std::floor(tmpR(2) / periodLength_m);
         tmpR(2) += startCoreField_m;
 
-        if (!fieldmap_m->isInside(tmpR)) return getFlagDeleteOnTransverseExit();
+        if (!fieldmap_m->isInside(tmpR)) return;
 
         tmpcos = (scaleCore_m + scaleCoreError_m) * std::cos(omega_t + phaseCore1_m + phaseError_m);
         tmpsin =
@@ -156,7 +154,7 @@ bool TravelingWave::apply(
 
     } else {
         tmpR(2) -= mappedStartExitField_m;
-        if (!fieldmap_m->isInside(tmpR)) return getFlagDeleteOnTransverseExit();
+        if (!fieldmap_m->isInside(tmpR)) return;
 
         tmpcos = (scale_m + scaleError_m) * std::cos(omega_t + phaseExit_m + phaseError_m);
         tmpsin = -(scale_m + scaleError_m) * std::sin(omega_t + phaseExit_m + phaseError_m);
@@ -165,8 +163,6 @@ bool TravelingWave::apply(
     fieldmap_m->getFieldstrength(tmpR, tmpE, tmpB);
     E += tmpcos * tmpE;
     B += tmpsin * tmpB;
-
-    return false;
 }
 
 bool TravelingWave::applyToReferenceParticle(

--- a/src/AbsBeamline/TravelingWave.h
+++ b/src/AbsBeamline/TravelingWave.h
@@ -55,9 +55,9 @@ public:
     virtual double getAutoPhaseEstimate(
             const double& E0, const double& t0, const double& q, const double& m) override;
 
-    virtual bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    virtual void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    virtual bool apply(
+    virtual void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/VariableRFCavity.cpp
+++ b/src/AbsBeamline/VariableRFCavity.cpp
@@ -101,17 +101,17 @@ Geometry& VariableRFCavity::getGeometry() { return geometry; }
 
 const Geometry& VariableRFCavity::getGeometry() const { return geometry; }
 
-bool VariableRFCavity::apply(
+void VariableRFCavity::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& t,
         Vector_t<double, 3>& E, Vector_t<double, 3>& /*B*/) {
     const double E0        = amplitudeTD_m->getValue(t) * Units::MVpm2Vpm;
     const double integralF = frequencyTD_m->getIntegral(t) * Units::MHz2Hz;
     const double phi       = phaseTD_m->getValue(t);
-    return computeField(
+    computeField(
             R, E, E0, integralF, phi, halfWidth_m, halfHeight_m, getGeometry().getElementLength());
 }
 
-bool VariableRFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
+void VariableRFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
     const auto R           = pc->R.getView();
     const auto E           = pc->E.getView();
     const auto t           = RefPartBunch_m->getT();
@@ -127,14 +127,16 @@ bool VariableRFCavity::apply(const std::shared_ptr<ParticleContainer_t>& pc) {
             "VariableRFCavity::computeField()", count, KOKKOS_LAMBDA(const size_t i) {
                 computeField(R(i), E(i), E0, integralF, phi, halfWidth, halfHeight, length);
             });
-
-    return false;
 }
 
 bool VariableRFCavity::applyToReferenceParticle(
-        const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
-        Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
-    return apply(R, P, t, E, B);
+        const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double& t,
+        Vector_t<double, 3>& E, Vector_t<double, 3>& /*B*/) {
+    const double E0        = amplitudeTD_m->getValue(t) * Units::MVpm2Vpm;
+    const double integralF = frequencyTD_m->getIntegral(t) * Units::MHz2Hz;
+    const double phi       = phaseTD_m->getValue(t);
+    return computeField(
+            R, E, E0, integralF, phi, halfWidth_m, halfHeight_m, getGeometry().getElementLength());
 }
 
 void VariableRFCavity::initialise(PartBunch_t* bunch) { RefPartBunch_m = bunch; }

--- a/src/AbsBeamline/VariableRFCavity.h
+++ b/src/AbsBeamline/VariableRFCavity.h
@@ -59,7 +59,7 @@ public:
     void accept(BeamlineVisitor& visitor) const override;
 
     /** Apply the field to all particles in the container */
-    bool apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
+    void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
     /** Calculate the field at a given position
      *
@@ -68,10 +68,8 @@ public:
      *  @param t the time at which the field is calculated
      *  @param E return value; filled with electric field strength
      *  @param B return value; filled with magnetic field strength
-     *
-     *  @returns True if particle is outside the boundaries; else False
      */
-    bool apply(
+    void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
             Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 

--- a/src/AbsBeamline/VerticalFFAMagnet.h
+++ b/src/AbsBeamline/VerticalFFAMagnet.h
@@ -36,7 +36,7 @@ public:
     ~VerticalFFAMagnet();
 
     /** Inheritable copy constructor */
-    ElementBase* clone() const;
+    ElementBase* clone() const override;
 
     /** Calculate the field at the position of the ith particle
      *
@@ -45,11 +45,10 @@ public:
      *  \param t time at which the field is to be calculated
      *  \param E calculated electric field - always 0 (no E-field)
      *  \param B calculated magnetic field
-     *  \returns true if particle is outside the field map
      */
-    inline bool apply(const std::shared_ptr<ParticleContainer_t>& pc);
+    inline void apply(const std::shared_ptr<ParticleContainer_t>& pc) override;
 
-    inline bool apply(
+    inline void apply(
             const size_t& i, const double& t, Vector_t<double, 3>& E, Vector_t<double, 3>& B);
 
     /** Calculate the field at some arbitrary position
@@ -59,11 +58,10 @@ public:
      *  \param t not used
      *  \param E not used
      *  \param B calculated magnetic field
-     *  \returns true if particle is outside the field map, else false
      */
-    inline bool apply(
+    inline void apply(
             const Vector_t<double, 3>& R, const Vector_t<double, 3>& P, const double& t,
-            Vector_t<double, 3>& E, Vector_t<double, 3>& B);
+            Vector_t<double, 3>& E, Vector_t<double, 3>& B) override;
 
     /** Calculate the field at some arbitrary position in cartesian coordinates
      *
@@ -80,7 +78,7 @@ public:
      *  \param startField not used
      *  \param endField not used
      */
-    void initialise(PartBunch_t* bunch);
+    void initialise(PartBunch_t* bunch) override;
 
     /** Initialise the VerticalFFAMagnet
      *
@@ -90,7 +88,7 @@ public:
     void initialise();
 
     /** Finalise the VerticalFFAMagnet - sets bunch to nullptr */
-    void finalise();
+    void finalise() override;
 
     /** Return false - VerticalFFAMagnet is a straight magnet
      *
@@ -99,16 +97,16 @@ public:
      */
 
     /** Not implemented */
-    void getFieldExtent(double& /*zBegin*/, double& /*zEnd*/) const {}
+    void getFieldExtent(double& /*zBegin*/, double& /*zEnd*/) const override {}
 
     /** Return the cell geometry */
-    Geometry& getGeometry();
+    Geometry& getGeometry() override;
 
     /** Return the cell geometry */
-    const Geometry& getGeometry() const;
+    const Geometry& getGeometry() const override;
 
     /** Accept a beamline visitor */
-    void accept(BeamlineVisitor& visitor) const;
+    void accept(BeamlineVisitor& visitor) const override;
 
     /** Get the fringe field
      *
@@ -211,22 +209,22 @@ void VerticalFFAMagnet::setPositiveVerticalExtent(double positiveExtent) {
     zPosExtent_m = positiveExtent * mm;
 }
 
-bool VerticalFFAMagnet::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) { return false; }
+void VerticalFFAMagnet::apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) {}
 
-bool VerticalFFAMagnet::apply(
+void VerticalFFAMagnet::apply(
         const size_t& i, const double& t, Vector_t<double, 3>& E, Vector_t<double, 3>& B) {
     std::shared_ptr<ParticleContainer_t> pc = RefPartBunch_m->getParticleContainer();
     auto Rview                              = pc->R.getView();
     auto Pview                              = pc->P.getView();
     const Vector_t<double, 3> R             = Rview(i);
     const Vector_t<double, 3> P             = Pview(i);
-    return apply(R, P, t, E, B);
+    apply(R, P, t, E, B);
 }
 
-bool VerticalFFAMagnet::apply(
+void VerticalFFAMagnet::apply(
         const Vector_t<double, 3>& R, const Vector_t<double, 3>& /*P*/, const double&,
         Vector_t<double, 3>& /*E*/, Vector_t<double, 3>& B) {
-    return getFieldValue(R, B);
+    getFieldValue(R, B);
 }
 
 std::vector<std::vector<double> > VerticalFFAMagnet::getDfCoefficients() const {

--- a/unit_tests/AbsBeamline/TestConstantEFieldCavity.cpp
+++ b/unit_tests/AbsBeamline/TestConstantEFieldCavity.cpp
@@ -71,9 +71,8 @@ namespace {
         Vector_t<double, 3> E = {1.0, 2.0, 3.0};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 1.0);
         EXPECT_DOUBLE_EQ(E(1), 2.0);
         EXPECT_DOUBLE_EQ(E(2), 3.0 + 10.0);
@@ -85,9 +84,8 @@ namespace {
         Vector_t<double, 3> E = {1.0, 2.0, 3.0};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 1.0);
         EXPECT_DOUBLE_EQ(E(1), 2.0);
         EXPECT_DOUBLE_EQ(E(2), 3.0);
@@ -99,9 +97,8 @@ namespace {
         Vector_t<double, 3> E = {1.0, 2.0, 3.0};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 1.0);
         EXPECT_DOUBLE_EQ(E(1), 2.0);
         EXPECT_DOUBLE_EQ(E(2), 3.0);
@@ -113,9 +110,8 @@ namespace {
         Vector_t<double, 3> E = {0.0, 0.0, 0.0};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 0.0);
         EXPECT_DOUBLE_EQ(E(1), 0.0);
         EXPECT_DOUBLE_EQ(E(2), 10.0);
@@ -127,9 +123,8 @@ namespace {
         Vector_t<double, 3> E = {0.0, 0.0, 0.0};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 0.0);
         EXPECT_DOUBLE_EQ(E(1), 0.0);
         EXPECT_DOUBLE_EQ(E(2), 10.0);
@@ -145,9 +140,8 @@ namespace {
         Vector_t<double, 3> E = {0.5, 0.5, 0.5};
         Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-        bool out = rep_->apply(R, P, 0.0, E, B);
+        rep_->apply(R, P, 0.0, E, B);
 
-        EXPECT_FALSE(out);
         EXPECT_DOUBLE_EQ(E(0), 0.5 + 1.0);
         EXPECT_DOUBLE_EQ(E(1), 0.5 - 2.0);
         EXPECT_DOUBLE_EQ(E(2), 0.5 + 3.0);

--- a/unit_tests/AbsBeamline/TestMonitor.cpp
+++ b/unit_tests/AbsBeamline/TestMonitor.cpp
@@ -180,10 +180,10 @@ TEST_F(MonitorTest, IsInsideRejectsPointsOutsideElementLength) {
 // ---------------------------------------------------------------------------
 // Safe early returns
 // ---------------------------------------------------------------------------
-TEST_F(MonitorTest, ApplyNullParticleContainerReturnsFalse) {
+TEST_F(MonitorTest, ApplyNullParticleContainerIsSafe) {
     TestMonitor monitor;
 
-    EXPECT_FALSE(monitor.apply(std::shared_ptr<ParticleContainer_t>()));
+    EXPECT_NO_THROW(monitor.apply(std::shared_ptr<ParticleContainer_t>()));
 }
 
 TEST_F(MonitorTest, ApplyToReferenceParticleWithoutReferenceBunchReturnsFalse) {
@@ -199,7 +199,7 @@ TEST_F(MonitorTest, ApplyToReferenceParticleWithoutReferenceBunchReturnsFalse) {
     EXPECT_FALSE(monitor.applyToReferenceParticle(R, P, 0.0, E, B));
 }
 
-TEST_F(MonitorTest, FieldOnlyApplyOverloadReturnsFalseAndLeavesFieldsUnchanged) {
+TEST_F(MonitorTest, FieldOnlyApplyOverloadLeavesFieldsUnchanged) {
     TestMonitor monitor;
 
     Vector_t<double, 3> R(0.0);
@@ -215,7 +215,7 @@ TEST_F(MonitorTest, FieldOnlyApplyOverloadReturnsFalseAndLeavesFieldsUnchanged) 
     B(1) = 5.0;
     B(2) = 6.0;
 
-    EXPECT_FALSE(monitor.apply(R, P, 0.0, E, B));
+    monitor.apply(R, P, 0.0, E, B);
 
     EXPECT_DOUBLE_EQ(E(0), 1.0);
     EXPECT_DOUBLE_EQ(E(1), 2.0);

--- a/unit_tests/AbsBeamline/TestRFCavity.cpp
+++ b/unit_tests/AbsBeamline/TestRFCavity.cpp
@@ -219,10 +219,10 @@ TEST_F(RFCavityTest, BodyExtentCanDifferFromFieldSupport) {
 
     Vector_t<double, 3> E = {0.0, 0.0, 0.0};
     Vector_t<double, 3> B = {0.0, 0.0, 0.0};
-    EXPECT_FALSE(cav_->apply({0.0, 0.0, 0.1}, {0.0, 0.0, 1.0}, 0.0, E, B));
+    cav_->apply({0.0, 0.0, 0.1}, {0.0, 0.0, 1.0}, 0.0, E, B);
     EXPECT_DOUBLE_EQ(E(0), 0.0);
 
-    EXPECT_FALSE(cav_->apply({0.0, 0.0, 0.5}, {0.0, 0.0, 1.0}, 0.0, E, B));
+    cav_->apply({0.0, 0.0, 0.5}, {0.0, 0.0, 1.0}, 0.0, E, B);
     EXPECT_DOUBLE_EQ(E(0), 1.0);
 }
 
@@ -464,7 +464,11 @@ TEST_F(RFCavityTest, FieldmapOutOfBounds) {
     Vector_t<double, 3> E = {0.0, 0.0, 0.0};
     Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-    bool out = cav_->apply(R, P, 0.0, E, B);
+    cav_->apply(R, P, 0.0, E, B);
 
-    EXPECT_TRUE(out);
+    // Out-of-bounds: no field is applied.
+    EXPECT_DOUBLE_EQ(E(0), 0.0);
+    EXPECT_DOUBLE_EQ(E(1), 0.0);
+    EXPECT_DOUBLE_EQ(E(2), 0.0);
+    EXPECT_TRUE(cav_->applyToReferenceParticle(R, P, 0.0, E, B));
 }

--- a/unit_tests/AbsBeamline/TestTravelingWave.cpp
+++ b/unit_tests/AbsBeamline/TestTravelingWave.cpp
@@ -407,8 +407,13 @@ TEST_F(TravelingWaveTest, FieldmapOutOfBounds) {
     Vector_t<double, 3> E = {0.0, 0.0, 0.0};
     Vector_t<double, 3> B = {0.0, 0.0, 0.0};
 
-    bool out = tw_->apply(R, P, 0.0, E, B);
-    EXPECT_TRUE(out);
+    tw_->apply(R, P, 0.0, E, B);
+
+    // Out-of-bounds: no field is applied.
+    EXPECT_DOUBLE_EQ(E(0), 0.0);
+    EXPECT_DOUBLE_EQ(E(1), 0.0);
+    EXPECT_DOUBLE_EQ(E(2), 0.0);
+    EXPECT_TRUE(tw_->applyToReferenceParticle(R, P, 0.0, E, B));
 }
 
 TEST_F(TravelingWaveTest, IsInside) {

--- a/unit_tests/AbsBeamline/TestVariableRFCavity.cpp
+++ b/unit_tests/AbsBeamline/TestVariableRFCavity.cpp
@@ -276,7 +276,7 @@ TEST_F(TestVariableRFCavity, TestApplyField) {
         const double integralF = poly2->getIntegral(t) * Units::MHz2Hz;
         const double e_test =
                 amplitude * sin(Physics::two_pi * integralF + phase) * Units::MVpm2Vpm;
-        EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+        EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
         EXPECT_NEAR(0., E[0], 1.e-6);
         EXPECT_NEAR(0., E[1], 1.e-6);
         EXPECT_NEAR(e_test, E[2], 1.e-6);
@@ -301,28 +301,28 @@ TEST_F(TestVariableRFCavity, TestApplyBoundingBox) {
     Vector_t<double, 3> B({0., 0., 0.});
     Vector_t<double, 3> E({0., 0., 0.});
     double t = 0;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[2] = 2. - 1e-9;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[2] = 1.e-9;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[2] = -1.e-9;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[2] = 2. + 1.e-9;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[2] = 1.;
     R[1] = -1.5 - 1e-9;
-    EXPECT_TRUE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_TRUE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[1] = +1.5 + 1e-9;
-    EXPECT_TRUE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_TRUE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[1] = 0.;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[0] = -2. - 1e-9;
-    EXPECT_TRUE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_TRUE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[0] = +2. + 1e-9;
-    EXPECT_TRUE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_TRUE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
     R[0] = 0.;
-    EXPECT_FALSE(cav1.apply(R, Vector_t<double, 3>(0.0), t, E, B));
+    EXPECT_FALSE(cav1.applyToReferenceParticle(R, Vector_t<double, 3>(0.0), t, E, B));
 }
 
 TEST_F(TestVariableRFCavity, BunchFields) {
@@ -376,7 +376,7 @@ TEST_F(TestVariableRFCavity, BunchFields) {
     Vector_t<double, 3> singleE{}, singleB{};
     const auto hostR0 = Kokkos::create_mirror_view(pc->R.getView());
     Kokkos::deep_copy(hostR0, pc->R.getView());
-    EXPECT_FALSE(apply(hostR0(0), Vector_t<double, 3>{}, 0.0, singleE, singleB));
+    EXPECT_FALSE(applyToReferenceParticle(hostR0(0), Vector_t<double, 3>{}, 0.0, singleE, singleB));
     EXPECT_DOUBLE_EQ(singleE[2], 1.0 * Units::MVpm2Vpm);
     // Done
     finalise();
@@ -443,8 +443,8 @@ TEST_F(TestVariableRFCavity, FieldSupportMatchesBodyLength) {
     EXPECT_DOUBLE_EQ(zEnd, 10.0);
 
     Vector_t<double, 3> E{}, B{};
-    EXPECT_FALSE(apply({0.0, 0.0, -0.1}, {}, 0.0, E, B));
+    EXPECT_FALSE(applyToReferenceParticle({0.0, 0.0, -0.1}, {}, 0.0, E, B));
     EXPECT_DOUBLE_EQ(E[2], 0.0);
-    EXPECT_FALSE(apply({0.0, 0.0, 5.0}, {}, 0.0, E, B));
+    EXPECT_FALSE(applyToReferenceParticle({0.0, 0.0, 5.0}, {}, 0.0, E, B));
     EXPECT_DOUBLE_EQ(E[2], 1.0 * Units::MVpm2Vpm);
 }

--- a/unit_tests/Algorithms/TestOrbitThreader.cpp
+++ b/unit_tests/Algorithms/TestOrbitThreader.cpp
@@ -50,13 +50,11 @@ namespace {
         void accept(BeamlineVisitor&) const override {}
         ElementBase* clone() const override { return new FieldSupportOnlyComponent(*this); }
 
-        bool apply(const std::shared_ptr<ParticleContainer_t>&) override { return false; }
+        void apply(const std::shared_ptr<ParticleContainer_t>&) override {}
 
-        bool apply(
+        void apply(
                 const Vector_t<double, 3>&, const Vector_t<double, 3>&, const double&,
-                Vector_t<double, 3>&, Vector_t<double, 3>&) override {
-            return false;
-        }
+                Vector_t<double, 3>&, Vector_t<double, 3>&) override {}
 
         bool applyToReferenceParticle(
                 const Vector_t<double, 3>&, const Vector_t<double, 3>&, const double&,

--- a/unit_tests/BasicActions/TestDumpEMFields.cpp
+++ b/unit_tests/BasicActions/TestDumpEMFields.cpp
@@ -45,12 +45,12 @@ namespace {
         ~MockComponent() override = default;
         void accept(BeamlineVisitor&) const override {}
         ElementBase* clone() const override { return new MockComponent(*this); }
-        bool apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) override { return false; }
-        bool apply(
+        void apply(const std::shared_ptr<ParticleContainer_t>& /*pc*/) override {}
+        void apply(
                 const Vector_t<double, 3>& r, const Vector_t<double, 3>& /*P*/, const double& /*t*/,
                 Vector_t<double, 3>& E, Vector_t<double, 3>& B) override {
             if (r(0) < 0. || r(0) > 1. || r(1) < -1. || r(1) > 0. || r(2) < 0. || r(2) > 1.) {
-                return true;  // isOutOfBounds
+                return;  // out of bounds: no field
             }
             B(0) = r(0);
             B(1) = r(1);
@@ -58,7 +58,6 @@ namespace {
             E(0) = -r(0);
             E(1) = -r(1);
             E(2) = -r(2);
-            return false;  // NOT isOutOfBounds
         }
         bool applyToReferenceParticle(
                 const Vector_t<double, 3>& /*r*/, const Vector_t<double, 3>& /*P*/,


### PR DESCRIPTION
In order to keep PRs small, I will implement the aperture in two parts. 

In this part I simply change the return type of the elements' `apply()` functions. Previously, these were `bool`, and were supposed to indicated whether or not a particle was lost inside the elements. 

The mechanism to delete particles inside elements due to the aperture will be overhauled in the second part and will use the existing index array and not depend on the `bool` return type. This is in line with the particle deletion because of decay and 

