### PR TITLE
Add guards against wrong indices for `TestSolve2d5`

### DIFF
--- a/src/PartBunch/Solve2d5.hpp
+++ b/src/PartBunch/Solve2d5.hpp
@@ -569,8 +569,11 @@ KOKKOS_FUNCTION void Solve2d5<T>::doGatherFromGrid(
         diagnostic.deboostFromBeam(n, e(n), b(n), invalid(n));
         // Calculate the longitudinal E field in Frenet-Serret coordinates
         const int index = (fsR.data_m[2] - origin.data_m[2]) * invDr.data_m[2] + 0.5;
-        const auto ldg  = lineDensityGradient(index);
-        e(n).data_m[2]  = gBy4PiEpsilon0 * ldg / beamGamma / beamGamma;
+        T ldg{};
+        if (index >= 0 && index < static_cast<int>(lineDensityGradient.extent(0))) {
+            ldg = lineDensityGradient(index);
+        }
+        e(n).data_m[2] = gBy4PiEpsilon0 * ldg / beamGamma / beamGamma;
         diagnostic.longitudinalField(n, e(n), b(n), invalid(n));
         // And finally back into lab coordinates
         convertFromFrenetSerret(n, bUnit, nUnit, tUnit, e, b);


### PR DESCRIPTION
closes #511 

See attached issue for an explanation. 

@Jonathan-A-Thompson: it would be nice if you could quickly say if the fix makes sense as is.