### PR TITLE
Explicit `DESIGNENERGY` handling

### DIFF
--- a/src/AbsBeamline/RBend.h
+++ b/src/AbsBeamline/RBend.h
@@ -91,12 +91,12 @@ public:
     void setFringeIntegral(double fringeIntegral);
 
     /// @brief Set the design energy.
-    /// @param energy The design energy.
+    /// @param energy The design energy in eV.
     /// @param changeable Whether the design energy can be changed later.
     void setDesignEnergy(const double& energy, bool changeable = true) override;
 
     /// @brief Get the design energy.
-    /// @return The design energy.
+    /// @return The design energy in eV.
     double getDesignEnergy() const override;
 
     /// @brief Store the normal/skew multipole coefficients into the device views
@@ -176,7 +176,7 @@ inline void RBend::setFringeIntegral(double fringeIntegral) {
 
 inline void RBend::setDesignEnergy(const double& energy, bool changeable) {
     if (designEnergyChangeable_m) {
-        designEnergy_m           = std::abs(energy) * 1e6;
+        designEnergy_m           = std::abs(energy);
         designEnergyChangeable_m = changeable;
     }
 }

--- a/src/AbsBeamline/SBend.h
+++ b/src/AbsBeamline/SBend.h
@@ -100,12 +100,12 @@ public:
     void setFringeIntegral(double fringeIntegral);
 
     /// @brief Set the design energy.
-    /// @param energy The design energy.
+    /// @param energy The design energy in eV.
     /// @param changeable Whether the design energy can be changed later.
     void setDesignEnergy(const double& energy, bool changeable = true) override;
 
     /// @brief Get the design energy.
-    /// @return The design energy.
+    /// @return The design energy in eV.
     double getDesignEnergy() const override;
 
     /// @brief Store the normal/skew multipole coefficients into the device views
@@ -179,7 +179,7 @@ inline void SBend::setFringeIntegral(double fringeIntegral) {
 
 inline void SBend::setDesignEnergy(const double& energy, bool changeable) {
     if (designEnergyChangeable_m) {
-        designEnergy_m           = std::abs(energy) * 1e6;
+        designEnergy_m           = std::abs(energy);
         designEnergyChangeable_m = changeable;
     }
 }

--- a/src/Elements/OpalRBend.cpp
+++ b/src/Elements/OpalRBend.cpp
@@ -95,7 +95,9 @@ void OpalRBend::update() {
 
     // Energy in eV.
     if (itsAttr[DESIGNENERGY]) {
-        bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
+        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
+        throw OpalException(
+                "OpalRBend::update", "DESIGNENERGY is not supported yet for the OPALX-native RBEND port.");
     }
 
     if (itsAttr[GAP])

--- a/src/Elements/OpalRBend.cpp
+++ b/src/Elements/OpalRBend.cpp
@@ -96,9 +96,10 @@ void OpalRBend::update() {
 
     // Energy in eV.
     if (itsAttr[DESIGNENERGY]) {
-        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
+        // bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
         throw OpalException(
-                "OpalRBend::update", "DESIGNENERGY is not supported yet for the OPALX-native RBEND port.");
+                "OpalRBend::update",
+                "DESIGNENERGY is not supported yet for the OPALX-native RBEND port.");
     }
 
     if (itsAttr[GAP])

--- a/src/Elements/OpalRBend.cpp
+++ b/src/Elements/OpalRBend.cpp
@@ -95,7 +95,7 @@ void OpalRBend::update() {
 
     // Energy in eV.
     if (itsAttr[DESIGNENERGY]) {
-        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
+        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
         throw OpalException(
                 "OpalRBend::update", "DESIGNENERGY is not supported yet for the OPALX-native RBEND port.");
     }

--- a/src/Elements/OpalRBend.cpp
+++ b/src/Elements/OpalRBend.cpp
@@ -21,6 +21,7 @@
 #include "Attributes/Attributes.h"
 #include "BeamlineCore/RBendRep.h"
 #include "Physics/Physics.h"
+#include "Physics/Units.h"
 #include "Utilities/OpalException.h"
 
 OpalRBend::OpalRBend()

--- a/src/Elements/OpalSBend.cpp
+++ b/src/Elements/OpalSBend.cpp
@@ -101,10 +101,11 @@ void OpalSBend::update() {
 
     // Units are eV.
     if (itsAttr[DESIGNENERGY]) {
-        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
+        // bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
         throw OpalException(
-            "OpalSBend::update", "DESIGNENERGY is not supported yet for the OPALX-native SBEND port.");
-}
+                "OpalSBend::update",
+                "DESIGNENERGY is not supported yet for the OPALX-native SBEND port.");
+    }
 
     if (itsAttr[GAP])
         throw OpalException(

--- a/src/Elements/OpalSBend.cpp
+++ b/src/Elements/OpalSBend.cpp
@@ -100,9 +100,9 @@ void OpalSBend::update() {
 
     // Units are eV.
     if (itsAttr[DESIGNENERGY]) {
-        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
+        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]) * Units::MeV2eV, false);
         throw OpalException(
-            "OpalRBend::update", "DESIGNENERGY is not supported yet for the OPALX-native SBEND port.");
+            "OpalSBend::update", "DESIGNENERGY is not supported yet for the OPALX-native SBEND port.");
 }
 
     if (itsAttr[GAP])

--- a/src/Elements/OpalSBend.cpp
+++ b/src/Elements/OpalSBend.cpp
@@ -100,8 +100,10 @@ void OpalSBend::update() {
 
     // Units are eV.
     if (itsAttr[DESIGNENERGY]) {
-        bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
-    }
+        //bend->setDesignEnergy(Attributes::getReal(itsAttr[DESIGNENERGY]), false);
+        throw OpalException(
+            "OpalRBend::update", "DESIGNENERGY is not supported yet for the OPALX-native SBEND port.");
+}
 
     if (itsAttr[GAP])
         throw OpalException(

--- a/src/Elements/OpalSBend.cpp
+++ b/src/Elements/OpalSBend.cpp
@@ -21,6 +21,7 @@
 #include "Attributes/Attributes.h"
 #include "BeamlineCore/SBendRep.h"
 #include "Physics/Physics.h"
+#include "Physics/Units.h"
 #include "Utilities/OpalException.h"
 
 OpalSBend::OpalSBend()


### PR DESCRIPTION
# Summary
This PR addresses the issue #518. 

It introduces explicit guards against the usage of `DESIGNENERGY` in the inputfile and preemptively fixes the unit issue should design energy be used in future. 

Closes #518 

# Testing
Unit and regression tests passing on CPU and GPU.