### PR TITLE
Fix RBend and SBend aperture

### DIFF
--- a/src/Elements/OpalBend.cpp
+++ b/src/Elements/OpalBend.cpp
@@ -27,27 +27,35 @@
 // ------------------------------------------------------------------------
 
 OpalBend::OpalBend(const char* name, const char* help) : OpalElement(SIZE, name, help) {
-    itsAttr[ANGLE]    = Attributes::makeReal("ANGLE", "Upright dipole coefficient in m^(-1)");
-    itsAttr[K0]       = Attributes::makeReal("K0", "Normal dipole coefficient in m^(-1)");
-    itsAttr[K0S]      = Attributes::makeReal("K0S", "Skew dipole coefficient in m^(-1)");
-    itsAttr[K1]       = Attributes::makeReal("K1", "Upright quadrupole coefficient in m^(-2)");
-    itsAttr[K1S]      = Attributes::makeReal("K1S", "Skew quadrupole coefficient in m^(-2)");
-    itsAttr[K2]       = Attributes::makeReal("K2", "Upright sextupole coefficient in m^(-3)");
-    itsAttr[K2S]      = Attributes::makeReal("K2S", "Skew sextupole coefficient in m^(-3)");
-    itsAttr[K3]       = Attributes::makeReal("K3", "Upright octupole coefficient in m^(-4)");
-    itsAttr[K3S]      = Attributes::makeReal("K3S", "Skew octupole coefficient in m^(-4)");
-    itsAttr[E1]       = Attributes::makeReal("E1", "Entry pole face angle in rad", 0.0);
-    itsAttr[E2]       = Attributes::makeReal("E2", "Exit pole face angle in rad", 0.0);
-    itsAttr[H1]       = Attributes::makeReal("H1", "Entry pole face curvature in m^(-1)");
-    itsAttr[H2]       = Attributes::makeReal("H2", "Exit pole face curvature in m^(-1)");
-    itsAttr[HGAP]     = Attributes::makeReal("HGAP", "Half gap height of the magnet (m)", 0.0);
+    itsAttr[ANGLE] = Attributes::makeReal("ANGLE", "Upright dipole coefficient in m^(-1)");
+    itsAttr[K0]    = Attributes::makeReal("K0", "Normal dipole coefficient in m^(-1)");
+    itsAttr[K0S]   = Attributes::makeReal("K0S", "Skew dipole coefficient in m^(-1)");
+    itsAttr[K1]    = Attributes::makeReal("K1", "Upright quadrupole coefficient in m^(-2)");
+    itsAttr[K1S]   = Attributes::makeReal("K1S", "Skew quadrupole coefficient in m^(-2)");
+    itsAttr[K2]    = Attributes::makeReal("K2", "Upright sextupole coefficient in m^(-3)");
+    itsAttr[K2S]   = Attributes::makeReal("K2S", "Skew sextupole coefficient in m^(-3)");
+    itsAttr[K3]    = Attributes::makeReal("K3", "Upright octupole coefficient in m^(-4)");
+    itsAttr[K3S]   = Attributes::makeReal("K3S", "Skew octupole coefficient in m^(-4)");
+    itsAttr[E1]    = Attributes::makeReal("E1", "Entry pole face angle in rad", 0.0);
+    itsAttr[E2]    = Attributes::makeReal("E2", "Exit pole face angle in rad", 0.0);
+    itsAttr[H1]    = Attributes::makeReal("H1", "Entry pole face curvature in m^(-1)");
+    itsAttr[H2]    = Attributes::makeReal("H2", "Exit pole face curvature in m^(-1)");
+    itsAttr[HGAP]  = Attributes::makeReal(
+            "HGAP",
+            "Half gap height of the magnet (m). Scales the fringe field and sets the "
+             "vertical half aperture",
+            0.0);
     itsAttr[FINT]     = Attributes::makeReal("FINT", "Field integral (no dimension)", 0.5);
     itsAttr[SLICES]   = Attributes::makeReal("SLICES", "Number of slices to use", 1.0);
     itsAttr[STEPSIZE] = Attributes::makeReal("STEPSIZE", "Step-size to use for integration");
     itsAttr[FMAPFN]   = Attributes::makeString("FMAPFN", "Filename for the fieldmap");
     itsAttr[GAP] =
             Attributes::makeReal("GAP", "Not supported; specify HGAP (the half gap) instead");
-    itsAttr[HAPERT] = Attributes::makeReal("HAPERT", "Bend plane magnet aperture (m)", 0.0);
+    itsAttr[HAPERT] = Attributes::makeReal(
+            "HAPERT",
+            "Half aperture in the bend plane, i.e. horizontal (m). Requires HGAP > 0 "
+            "and cannot be combined with APERTURE",
+            0.0);
     itsAttr[DESIGNENERGY] =
             Attributes::makeReal("DESIGNENERGY", "the mean energy of the particles in MeV");
     itsAttr[GREATERTHANPI] = Attributes::makeBool("GREATERTHANPI", "-- not supported any more --");

--- a/src/Elements/OpalRBend.cpp
+++ b/src/Elements/OpalRBend.cpp
@@ -17,6 +17,7 @@
 //
 #include "Elements/OpalRBend.h"
 #include <cmath>
+#include <string>
 #include "AbstractObjects/OpalData.h"
 #include "Attributes/Attributes.h"
 #include "BeamlineCore/RBendRep.h"
@@ -105,13 +106,56 @@ void OpalRBend::update() {
     bend->setFullGap(2.0 * Attributes::getReal(itsAttr[HGAP]));
     bend->setFringeIntegral(Attributes::getReal(itsAttr[FINT]));
 
-    // Only override the aperture when a positive HAPERT is actually given. HAPERT has a
-    // default of 0.0, and itsAttr[HAPERT] reads as "set" even when the deck omits it, so
-    // gating on presence would install a zero-width rectangular aperture that makes
-    // the aperture test always false and silently drops the bend from the beamline.
-    if (Attributes::getReal(itsAttr[HAPERT]) > 0.0) {
-        double hapert = Attributes::getReal(itsAttr[HAPERT]);
-        bend->setAperture(ApertureType::RECTANGULAR, std::vector<double>({hapert, hapert}));
+    // Transverse aperture. The vertical half-aperture is the pole gap HGAP; the horizontal
+    // one comes from HAPERT or from APERTURE, never from both. OpalElement::update() has
+    // already installed either the APERTURE string (full widths, halved by getApert()) or
+    // the 1e6 default, so this block only adds the gap and rejects the combinations that
+    // have no physical meaning.
+    //
+    // "Given" means written in the deck. HAPERT has a default, so itsAttr[HAPERT] reads as
+    // set even when the deck omits it; only defaultUsed() tells the two apart.
+    const bool hasApert  = !itsAttr[APERT].defaultUsed();
+    const bool hasHapert = !itsAttr[HAPERT].defaultUsed();
+    const double hgap    = Attributes::getReal(itsAttr[HGAP]);
+    const double hapert  = Attributes::getReal(itsAttr[HAPERT]);
+
+    if (hasApert && hasHapert) {
+        throw OpalException(
+                "OpalRBend::update",
+                getOpalName()
+                        + ": APERTURE and HAPERT cannot both be given. APERTURE sets both "
+                          "half-apertures, HAPERT only the horizontal one.");
+    }
+    if ((hasApert || hasHapert) && hgap <= 0.0) {
+        throw OpalException(
+                "OpalRBend::update",
+                getOpalName()
+                        + ": HAPERT/APERTURE requires a positive HGAP; the vertical aperture "
+                          "is the half gap.");
+    }
+    if (hasHapert && hapert <= 0.0) {
+        throw OpalException("OpalRBend::update", getOpalName() + ": HAPERT must be positive.");
+    }
+
+    auto aperture = bend->getAperture();
+    if (hasApert) {
+        // Keep the deck's own shape and half-widths, but the chamber cannot be taller than
+        // the poles it sits between. Equality is fine: flush with the pole faces.
+        if (aperture.second[1] > hgap) {
+            throw OpalException(
+                    "OpalRBend::update",
+                    getOpalName() + ": vertical half-aperture " + std::to_string(aperture.second[1])
+                            + " m exceeds the half gap HGAP = " + std::to_string(hgap) + " m.");
+        }
+    } else if (hgap > 0.0) {
+        // Flat poles above and below, a flat side wall left and right. Without HAPERT the
+        // horizontal half-width stays at the 1e6 default, i.e. vertical scraping only.
+        aperture.first     = ApertureType::RECTANGULAR;
+        aperture.second[1] = hgap;
+        if (hasHapert) {
+            aperture.second[0] = hapert;
+        }
+        bend->setAperture(aperture.first, aperture.second);
     }
 
     if (itsAttr[LENGTH])

--- a/src/Elements/OpalSBend.cpp
+++ b/src/Elements/OpalSBend.cpp
@@ -17,6 +17,7 @@
 //
 #include "Elements/OpalSBend.h"
 #include <cmath>
+#include <string>
 #include "AbstractObjects/OpalData.h"
 #include "Attributes/Attributes.h"
 #include "BeamlineCore/SBendRep.h"
@@ -110,17 +111,56 @@ void OpalSBend::update() {
     bend->setFullGap(2.0 * Attributes::getReal(itsAttr[HGAP]));
     bend->setFringeIntegral(Attributes::getReal(itsAttr[FINT]));
 
-    if (itsAttr[APERT])
-        throw OpalException(
-                "OpalSBend::update", "APERTURE in SBEND not supported; use GAP and HAPERT instead");
+    // Transverse aperture. The vertical half-aperture is the pole gap HGAP; the horizontal
+    // one comes from HAPERT or from APERTURE, never from both. OpalElement::update() has
+    // already installed either the APERTURE string (full widths, halved by getApert()) or
+    // the 1e6 default, so this block only adds the gap and rejects the combinations that
+    // have no physical meaning.
+    //
+    // "Given" means written in the deck. HAPERT has a default, so itsAttr[HAPERT] reads as
+    // set even when the deck omits it; only defaultUsed() tells the two apart.
+    const bool hasApert  = !itsAttr[APERT].defaultUsed();
+    const bool hasHapert = !itsAttr[HAPERT].defaultUsed();
+    const double hgap    = Attributes::getReal(itsAttr[HGAP]);
+    const double hapert  = Attributes::getReal(itsAttr[HAPERT]);
 
-    // Only override the aperture when a positive HAPERT is actually given. HAPERT has a
-    // default of 0.0, and itsAttr[HAPERT] reads as "set" even when the deck omits it, so
-    // gating on presence would install a zero-width rectangular aperture that makes
-    // the aperture test always false and silently drops the bend from the beamline.
-    if (Attributes::getReal(itsAttr[HAPERT]) > 0.0) {
-        double hapert = Attributes::getReal(itsAttr[HAPERT]);
-        bend->setAperture(ApertureType::RECTANGULAR, std::vector<double>({hapert, hapert}));
+    if (hasApert && hasHapert) {
+        throw OpalException(
+                "OpalSBend::update",
+                getOpalName()
+                        + ": APERTURE and HAPERT cannot both be given. APERTURE sets both "
+                          "half-apertures, HAPERT only the horizontal one.");
+    }
+    if ((hasApert || hasHapert) && hgap <= 0.0) {
+        throw OpalException(
+                "OpalSBend::update",
+                getOpalName()
+                        + ": HAPERT/APERTURE requires a positive HGAP; the vertical aperture "
+                          "is the half gap.");
+    }
+    if (hasHapert && hapert <= 0.0) {
+        throw OpalException("OpalSBend::update", getOpalName() + ": HAPERT must be positive.");
+    }
+
+    auto aperture = bend->getAperture();
+    if (hasApert) {
+        // Keep the deck's own shape and half-widths, but the chamber cannot be taller than
+        // the poles it sits between. Equality is fine: flush with the pole faces.
+        if (aperture.second[1] > hgap) {
+            throw OpalException(
+                    "OpalSBend::update",
+                    getOpalName() + ": vertical half-aperture " + std::to_string(aperture.second[1])
+                            + " m exceeds the half gap HGAP = " + std::to_string(hgap) + " m.");
+        }
+    } else if (hgap > 0.0) {
+        // Flat poles above and below, a flat side wall left and right. Without HAPERT the
+        // horizontal half-width stays at the 1e6 default, i.e. vertical scraping only.
+        aperture.first     = ApertureType::RECTANGULAR;
+        aperture.second[1] = hgap;
+        if (hasHapert) {
+            aperture.second[0] = hapert;
+        }
+        bend->setAperture(aperture.first, aperture.second);
     }
 
     if (itsAttr[LENGTH])

--- a/unit_tests/Elements/CMakeLists.txt
+++ b/unit_tests/Elements/CMakeLists.txt
@@ -3,6 +3,7 @@ message(STATUS "Adding unit tests found in ${_relPath}")
 
 add_opalx_test(TestOpalMultipoleT USE_GTEST_MAIN)
 add_opalx_test(TestOpalDrift USE_GTEST_MAIN)
+add_opalx_test(TestOpalBend USE_GTEST_MAIN)
 add_opalx_test(TestOpalBeamlinePlacement USE_GTEST_MAIN)
 add_opalx_test(TestOpalPolynomialTimeDependence USE_GTEST_MAIN)
 add_opalx_test(TestOpalSplineTimeDependence USE_GTEST_MAIN)

--- a/unit_tests/Elements/TestOpalBend.cpp
+++ b/unit_tests/Elements/TestOpalBend.cpp
@@ -1,0 +1,212 @@
+//
+// Copyright (c) 2026, Paul Scherrer Institute, Villigen PSI, Switzerland
+// All rights reserved
+//
+// This file is part of OPALX.
+//
+// OPALX is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with OPALX. If not, see <https://www.gnu.org/licenses/>.
+//
+#include <mpi.h>
+
+#include "Ippl.h"
+
+#include "AbsBeamline/ElementBase.h"
+#include "Attributes/Attributes.h"
+#include "Elements/OpalElement.h"
+#include "Elements/OpalRBend.h"
+#include "Elements/OpalSBend.h"
+#include "Utilities/OpalException.h"
+#include "ValueDefinitions/RealVariable.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// The transverse aperture of a bend is bounded vertically by the pole gap (HGAP) and
+// horizontally by HAPERT or by APERTURE. HAPERT and APERTURE are mutually exclusive, and
+// neither works without a positive HGAP.
+
+namespace {
+
+    enum class BendKind { SBend, RBend };
+
+    /// What the deck writes. An unset field is left at its attribute default, which is
+    /// what update() distinguishes through Attribute::defaultUsed().
+    struct BendSpec {
+        std::optional<double> hgap;
+        std::optional<double> hapert;
+        std::optional<std::string> aperture;
+    };
+
+    std::unique_ptr<OpalElement> makeBend(BendKind kind, const BendSpec& spec) {
+        std::unique_ptr<OpalElement> bend;
+        if (kind == BendKind::SBend) {
+            bend = std::make_unique<OpalSBend>();
+        } else {
+            bend = std::make_unique<OpalRBend>();
+        }
+
+        Attributes::setReal(*bend->findAttribute("L"), 1.0);
+        Attributes::setReal(*bend->findAttribute("ELEMEDGE"), 0.0);
+        if (spec.hgap.has_value()) {
+            Attributes::setReal(*bend->findAttribute("HGAP"), spec.hgap.value());
+        }
+        if (spec.hapert.has_value()) {
+            Attributes::setReal(*bend->findAttribute("HAPERT"), spec.hapert.value());
+        }
+        if (spec.aperture.has_value()) {
+            Attributes::setString(*bend->findAttribute("APERTURE"), spec.aperture.value());
+        }
+        bend->update();
+        return bend;
+    }
+
+    void expectAperture(
+            const std::unique_ptr<OpalElement>& bend, ApertureType type,
+            const std::vector<double>& args) {
+        ElementBase* element = bend->getElement();
+        ASSERT_NE(element, nullptr);
+        const auto aperture = element->getAperture();
+        EXPECT_EQ(aperture.first, type);
+        ASSERT_EQ(aperture.second.size(), args.size());
+        for (size_t i = 0; i < args.size(); ++i) {
+            EXPECT_DOUBLE_EQ(aperture.second[i], args[i]) << "aperture arg " << i;
+        }
+    }
+
+    class TestOpalBend : public testing::TestWithParam<BendKind> {
+    protected:
+        // The bends allocate Kokkos views for their multipole coefficients, so the runtime
+        // has to be up before the first update().
+        static void SetUpTestSuite() {
+            int argc    = 0;
+            char** argv = nullptr;
+            ippl::initialize(argc, argv);
+        }
+
+        static void TearDownTestSuite() { ippl::finalize(); }
+
+        void SetUp() override {
+            // Both bends read OpalData::getP0() when scaling their multipole coefficients.
+            // In a full run the RealVariable exemplar creates and registers the P0 variable;
+            // without it getP0() dereferences a null pointer. Created once for the suite and
+            // intentionally never deleted, since OpalData keeps referring to it.
+            [[maybe_unused]] static RealVariable* p0Owner = new RealVariable();
+        }
+    };
+
+}  // namespace
+
+TEST_P(TestOpalBend, NoApertureAttributesKeepsTheDefault) {
+    expectAperture(makeBend(GetParam(), {}), ApertureType::ELLIPTICAL, {1e6, 1e6});
+}
+
+TEST_P(TestOpalBend, HgapAloneInstallsTheVerticalWall) {
+    // The poles are the vertical limit even when the deck asks for nothing else; the
+    // horizontal half-width stays at the "no limit" default.
+    BendSpec spec;
+    spec.hgap = 0.02;
+    expectAperture(makeBend(GetParam(), spec), ApertureType::RECTANGULAR, {1e6, 0.02});
+}
+
+TEST_P(TestOpalBend, HapertSetsTheHorizontalHalfWidthOnly) {
+    BendSpec spec;
+    spec.hgap   = 0.02;
+    spec.hapert = 0.15;
+    // Not {0.15, 0.15}: HAPERT is the bend-plane half-aperture, not a square.
+    expectAperture(makeBend(GetParam(), spec), ApertureType::RECTANGULAR, {0.15, 0.02});
+}
+
+TEST_P(TestOpalBend, HapertIsAHalfWidthWhileApertureTakesFullWidths) {
+    BendSpec fromHapert;
+    fromHapert.hgap   = 0.02;
+    fromHapert.hapert = 0.15;
+
+    BendSpec fromAperture;
+    fromAperture.hgap     = 0.02;
+    fromAperture.aperture = "RECTANGLE(0.3,0.04)";
+
+    // 0.15 written as HAPERT is the same wall as 0.3 written as an APERTURE full width.
+    expectAperture(makeBend(GetParam(), fromHapert), ApertureType::RECTANGULAR, {0.15, 0.02});
+    expectAperture(makeBend(GetParam(), fromAperture), ApertureType::RECTANGULAR, {0.15, 0.02});
+}
+
+TEST_P(TestOpalBend, ApertureKeepsItsOwnShape) {
+    BendSpec spec;
+    spec.hgap     = 0.02;
+    spec.aperture = "ELLIPSE(0.3,0.03)";
+    expectAperture(makeBend(GetParam(), spec), ApertureType::ELLIPTICAL, {0.15, 0.015});
+}
+
+TEST_P(TestOpalBend, ApertureFlushWithThePoleFacesIsAccepted) {
+    // Vertical half-aperture exactly HGAP: a chamber flush with the poles is legal.
+    BendSpec spec;
+    spec.hgap     = 0.02;
+    spec.aperture = "RECTANGLE(0.3,0.04)";
+    EXPECT_NO_THROW(makeBend(GetParam(), spec));
+}
+
+TEST_P(TestOpalBend, ApertureTallerThanTheGapThrows) {
+    BendSpec spec;
+    spec.hgap     = 0.02;
+    spec.aperture = "RECTANGLE(0.3,0.05)";  // vertical half-width 0.025 > HGAP
+    EXPECT_THROW(makeBend(GetParam(), spec), OpalException);
+}
+
+TEST_P(TestOpalBend, ApertureAndHapertTogetherThrow) {
+    BendSpec spec;
+    spec.hgap     = 0.02;
+    spec.hapert   = 0.15;
+    spec.aperture = "RECTANGLE(0.3,0.04)";
+    EXPECT_THROW(makeBend(GetParam(), spec), OpalException);
+}
+
+TEST_P(TestOpalBend, ScrapingWithoutAPositiveHgapThrows) {
+    BendSpec hapertNoHgap;
+    hapertNoHgap.hapert = 0.15;
+    EXPECT_THROW(makeBend(GetParam(), hapertNoHgap), OpalException);
+
+    BendSpec hapertZeroHgap;
+    hapertZeroHgap.hgap   = 0.0;
+    hapertZeroHgap.hapert = 0.15;
+    EXPECT_THROW(makeBend(GetParam(), hapertZeroHgap), OpalException);
+
+    BendSpec apertureNoHgap;
+    apertureNoHgap.aperture = "RECTANGLE(0.3,0.04)";
+    EXPECT_THROW(makeBend(GetParam(), apertureNoHgap), OpalException);
+
+    BendSpec apertureZeroHgap;
+    apertureZeroHgap.hgap     = 0.0;
+    apertureZeroHgap.aperture = "RECTANGLE(0.3,0.04)";
+    EXPECT_THROW(makeBend(GetParam(), apertureZeroHgap), OpalException);
+}
+
+TEST_P(TestOpalBend, ExplicitZeroHapertThrows) {
+    // A zero half-aperture would put every particle outside the element.
+    BendSpec spec;
+    spec.hgap   = 0.02;
+    spec.hapert = 0.0;
+    EXPECT_THROW(makeBend(GetParam(), spec), OpalException);
+}
+
+TEST_P(TestOpalBend, HardEdgeWithoutScrapingStillWorks) {
+    // HGAP = 0 means "no fringe modelled". It is only an error together with HAPERT or
+    // APERTURE; on its own it must leave the bend unrestricted.
+    BendSpec spec;
+    spec.hgap = 0.0;
+    expectAperture(makeBend(GetParam(), spec), ApertureType::ELLIPTICAL, {1e6, 1e6});
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        Bends, TestOpalBend, testing::Values(BendKind::SBend, BendKind::RBend),
+        [](const testing::TestParamInfo<BendKind>& info) {
+            return info.param == BendKind::SBend ? "SBEND" : "RBEND";
+        });


### PR DESCRIPTION
## Summary
This PR addresses the issue #522.

The aperture functionality shared among all the other elements now works correctly for the bending element while respecting the physical constraint on the vertical aperture defined by the magnet pole faces gap `HGAP`. 

Unit tests to ensure ill-defined apertures cause an error during parsing. 

## Testing
Passing all regression and unit tests on CPU and GPU.

Closes #522.

